### PR TITLE
Fix OSX "Data element too large" error

### DIFF
--- a/src/html/htmlparser.pas
+++ b/src/html/htmlparser.pas
@@ -333,7 +333,7 @@ function PrefixMatch(const Value, Candidate: UTF8String): Boolean;
 type
    TBlob = Pointer;
    PBlobArray = ^TBlobArray;
-   TBlobArray = array[0..MaxInt] of TBlob;
+   TBlobArray = array[0..0] of TBlob;
 var
    Steps, EndOfBlobs: Cardinal;
    Index: Cardinal;


### PR DESCRIPTION
See http://stackoverflow.com/a/32349608/441757

On OSX this compiles and runs/works in the http://github.com/whatwg/html build as expected without any errors or additional/unexpected warnings—both without the `-Px86_64` specified, and with it specified.

Would be good to test it on other platforms.

Despite what Marco says at http://stackoverflow.com/a/32349608/441757 about disabling runtime (range) checks in the source in order to make this work, in my testing in my environment at least, it doesn’t require that. But if needed I can add the pragmas (or whatever Pascal calls them) to turn off/on the range checks at the appropriate place in the code.