### PR TITLE
Set specific exit code to indicate a parse error

### DIFF
--- a/src/html/htmlparser.pas
+++ b/src/html/htmlparser.pas
@@ -35,6 +35,10 @@ uses
 // When optimising for a specific data set
 //{$DEFINE INSTRUMENTING}
 
+const
+   // per sysexits.h EX_DATAERR signals "the input data was incorrect"; e.g. a parse error
+   ecDataError: Integer = 65;
+
 type
 {$IFDEF USEROPES}
    TParserString = Rope;
@@ -1190,6 +1194,7 @@ procedure THTMLParser.ParseError(Message: UTF8String; const Count: Cardinal = 1)
 var
    Index: Cardinal;
 begin
+   exitcode := ecDataError;
    Assert(Count >= 1);
    {$IFDEF LINES}
    Message := '(' + IntToStr(FInputStream.Line) + ',' + IntToStr(FInputStream.Column) + ') ' + Message;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1187,7 +1187,9 @@ begin
    if (Errors > 0) then
    begin
       Writeln('Error count: ', Errors);
-      ExitCode := 1;
+      if (ExitCode = 0) then
+         // only set ExitCode to 1 if some other part of the code has not already set to other value
+         ExitCode := 1;
       // raise EAbort.Create(IntToStr(Errors) + ' errors found.');
    end;
 end;
@@ -2325,6 +2327,5 @@ begin
 end;
 
 begin
-   if (not Main()) then
-      Halt(1);
+   Main();
 end.


### PR DESCRIPTION
This change causes the exit code from wattsi to be set to `65` in the case where wattsi has reported any parse errors. For other errors, we continue to just [set the exit code to `1`](https://github.com/whatwg/wattsi/pull/6).

The special exit code for the has-parse-errors case is useful because parse errors are the only type of error for which wattsi currently emits line/column numbers—and it's useful to know if wattsi has reported any messages with line/column numbers.

And the reason it’s useful to know when wattsi has emitted messages with line/column numbers
is because in that case we want to get the correct line/column numbers from the raw source
(as opposed to the line/column numbers from pre-processed output from the raw source), which we can do by using the technique (hack) of re-running wattsi against the raw source if we know that wattsi has actually reported any messages with line/column numbers—and *not* re-running it against the raw source if no messages with line/column numbers have been reported. See https://github.com/whatwg/html-build/issues/50 for some background.

Assigning to @Hixie for a sanity check and to confirm whether he thinks this is a good idea or not.