### PR TITLE
Fix #16: Warn about unused references

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -766,7 +766,11 @@ var
             begin
                LastSeenReferenceName := Copy(LastSeenReferenceName, 5, Length(LastSeenReferenceName) - 4);
                if (not References.Has(LastSeenReferenceName)) then
+               begin
+                  if (Variant <> vDEV) then
+                     Warn('Unused reference: [' + LastSeenReferenceName + ']');
                   Result := False;
+               end
             end
             else
                LastSeenReferenceName := '';


### PR DESCRIPTION
This doesn't actually work, for me it warns about all the missing references and then crashes. Good enough to find the unused references, but not good enough for merging as-is.