### PR TITLE
add hash-bang line to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir -p bin
 cd src
 ./build.sh


### PR DESCRIPTION
Without the hash-bang some systems default to "sh" shell and this is inadequate for the build scripts.