### PR TITLE
Add id attribute to <dfn>s in headings

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -673,6 +673,7 @@ var
                if (Assigned(InHeading)) then
                begin
                   DFNEntry.DFNElement := InHeading;
+                  EnsureID(Element, MungeTopicToID(CrossReferenceName));
                   if (Element.HasAttribute(kCrossSpecRefAttribute)) then
                      Fail('A deferring definition can''t be in a heading, but this one is: ' + Describe(Element));
                end


### PR DESCRIPTION
This helps Shepherd make sense of what definitions are, e.g.
that the class="" attribute is a global attribute.