### PR TITLE
Fix #22: Munge URL-forbidden characters in IDs

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -296,7 +296,7 @@ var
       for IndexSource := 1 to Length(Original) do // $R-
       begin
          case Original[IndexSource] of
-            ' ', #$0A, '<', '>':
+            ' ', #$0A, '<', '>', '[', #$5C, ']', '^', '{', '|', '}':
                begin
                   if (not HadSpace) then
                   begin
@@ -305,7 +305,7 @@ var
                      HadSpace := True;
                   end;
                end;
-            '"', '?': ; // skipped silently
+            '"', '?', '`': ; // skipped silently
             'A'..'Z':
                begin
                   Inc(IndexTarget);


### PR DESCRIPTION
Replace [\]^{|} with a dash (when they separate words). Drop `.
(# is removed by MungeStringToTopic already, so not needed here.)