### PR TITLE
Avoid adding <a class=self-link> to TOCs

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -587,7 +587,7 @@ var
                      NewLink.AppendChild(CandidateChild);
                      CandidateChild := TempElement.FirstChild;
                      InSkippedNode := False;
-                     while (Assigned(CandidateChild)) do
+                     while (Assigned(CandidateChild) and ((not (CandidateChild is TElement)) or (TElement(CandidateChild).GetAttribute('class').AsString <> 'self-link'))) do
                      begin
                         if ((CandidateChild is TElement) and ((TElement(CandidateChild).IsIdentity(nsHTML, eDFN)) or (TElement(CandidateChild).IsIdentity(nsHTML, eSpan)))) then
                         begin


### PR DESCRIPTION
1572d7ee184601243c70e1e5994190f824de406e ended up adding links to the
TOCs of index.html and multipage/index.html though not individual
multi-page TOCs such as multipage/microdata.html. This avoids that.

A simpler fix would be to add

TElement(NewLink).RemoveChild(NewLink.lastChild);

after the while statement, but that seems less clean.