### PR TITLE
Report lack of <dfn> for <span>s without attributes

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -451,7 +451,7 @@ var
          CrossRefListNode^.Topic := CrossReferenceName;
          CrossRefListNode^.LastHeading := LastSeenHeadingID;
          CrossRefListNode^.Element := Element;
-         if (Element.HasAttribute(kCrossRefAttribute) or Element.IsIdentity(nsHTML, eCode)) then
+         if (Element.HasAttribute(kCrossRefAttribute) or Element.IsIdentity(nsHTML, eCode) or (Element.IsIdentity(nsHTML, eSpan) and not Assigned(Element.Attributes))) then
             CrossRefListNode^.Kind := crExplicit
          else
             CrossRefListNode^.Kind := crImplicit;


### PR DESCRIPTION
Only do this when the `<span>` has no attributes as using the
lang/class/id attributes should continue to be okay.

Fixes #33.