### PR TITLE
Include last good version in caniuse boxes

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1012,7 +1012,7 @@ var
 {$IFDEF VERBOSE_ANNOTATIONS} Writeln('    found=', Found); {$ENDIF}
             if (Found) then
             begin
-               P := E(eP, ['class', 'support'], [E(eStrong, [T('Support:')]), T(' ' + Feature.CanIUseCode, Document)]);
+               P := E(eP, ['class', 'support'], [E(eStrong, [T('Support:')]), T(' '), T(Feature.CanIUseCode, Document)]);
                for BrowserIndex in TBrowserIndex do
                begin
                   if (Feature.FirstGoodVersion[BrowserIndex].Version <> '') then

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -2008,6 +2008,7 @@ begin
 end;
 
 // http://wiki.freepascal.org/UTF8_strings_and_characters#Search_and_copy
+// TODO: SplitInHalf is expensive, should use ropes. https://github.com/whatwg/wattsi/issues/40
 function SplitInHalf(Txt, Separator: UTF8String; out Half1, Half2: UTF8String): Boolean;
 var
   i: Integer;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -84,6 +84,7 @@ type
    TVersionedState = record
       State: TImplGoodState;
       Version: UTF8String;
+      LastVersion: UTF8String;
    end;
    TFeature = record
       CanIUseCode: UTF8String;
@@ -1011,7 +1012,7 @@ var
 {$IFDEF VERBOSE_ANNOTATIONS} Writeln('    found=', Found); {$ENDIF}
             if (Found) then
             begin
-               P := E(eP, ['class', 'support'], [E(eStrong, [T('Support:')]), T(' ')]);
+               P := E(eP, ['class', 'support'], [E(eStrong, [T('Support:')]), T(' ' + Feature.CanIUseCode, Document)]);
                for BrowserIndex in TBrowserIndex do
                begin
                   if (Feature.FirstGoodVersion[BrowserIndex].Version <> '') then
@@ -1021,14 +1022,16 @@ var
                               P.AppendChild(E(eSpan, ['class', Browsers[BrowserIndex].Code + ' yes'], Document,
                                               [E(eSpan, [T(Browsers[BrowserIndex].Name, Document)]),
                                                T(' '),
-                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('+')])]));
+                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('-'),
+                                                         T(Feature.FirstGoodVersion[BrowserIndex].LastVersion, Document)])]));
                            end;
                         sAlmost:
                            begin
                               P.AppendChild(E(eSpan, ['class', Browsers[BrowserIndex].Code + ' partial'], Document,
                                               [E(eSpan, [E(eSpan, [T(Browsers[BrowserIndex].Name, Document)]),
                                                          T(' (limited) ')]),
-                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('+')])]));
+                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('-'),
+                                                         T(Feature.FirstGoodVersion[BrowserIndex].LastVersion, Document)])]));
                            end;
                         sNo:
                            begin
@@ -1047,7 +1050,7 @@ var
                if (Found) then
                   Status.AppendChild(E(eP, ['class', 'caniuse'], [T('Source: '), E(eA, ['href', 'http://caniuse.com/#feat=' + Feature.CanIUseCode], Document, [T('caniuse.com')])]))
                else
-                  Status.AppendChild(E(eP, ['class', 'caniuse'], [T('Soo also: '), E(eA, ['href', 'http://caniuse.com/#feat=' + Feature.CanIUseCode], Document, [T('caniuse.com')])]));
+                  Status.AppendChild(E(eP, ['class', 'caniuse'], [T('See also: '), E(eA, ['href', 'http://caniuse.com/#feat=' + Feature.CanIUseCode], Document, [T('caniuse.com')])]));
             end;
          end
          else
@@ -2089,6 +2092,7 @@ begin
          for BrowserIndex in TBrowserIndex do
          begin
             Feature.FirstGoodVersion[BrowserIndex].Version := '';
+            Feature.FirstGoodVersion[BrowserIndex].LastVersion := '';
             Browser := Browsers[BrowserIndex];
             for VersionIndex := High(Browsers[BrowserIndex].Versions) downto Low(Browsers[BrowserIndex].Versions) do // $R-
             begin
@@ -2116,6 +2120,8 @@ begin
                      NewState := sAlmost
                   else
                      NewState := sNo;
+                  if (Feature.FirstGoodVersion[BrowserIndex].Version = '') then
+                     Feature.FirstGoodVersion[BrowserIndex].LastVersion := Browser.Versions[VersionIndex];
                   if ((Feature.FirstGoodVersion[BrowserIndex].Version <> '') and (Feature.FirstGoodVersion[BrowserIndex].State <> NewState)) then
                      break;
                   Feature.FirstGoodVersion[BrowserIndex].Version := Browser.Versions[VersionIndex];

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -2002,11 +2002,25 @@ begin
       Writeln(Message);
 end;
 
+// http://wiki.freepascal.org/UTF8_strings_and_characters#Search_and_copy
+function SplitInHalf(Txt, Separator: UTF8String; out Half1, Half2: UTF8String): Boolean;
+var
+  i: Integer;
+begin
+  i := Pos(Separator, Txt);
+  Result := i > 0;
+  if Result then
+  begin
+    Half1 := Copy(Txt, 1, i-1);
+    Half2 := Copy(Txt, i+Length(Separator), Length(Txt));
+  end;
+end;
+
 procedure PreProcessCanIUseData(const CanIUseJSONFilename: AnsiString);
 var
    CanIUseData, Agent, Version, FeatureData: TJSON;
    Browser: TBrowser;
-   BrowserCode, FeatureCode, SpecURL, RawState, ID: UTF8String;
+   BrowserCode, FeatureCode, SpecURL, RawState, ID, LowVersion, HighVersion: UTF8String;
    CurrentUsage: Double;
    BrowserIndex, CopyIndex: TBrowserIndex;
    VersionIndex, StateIndex: Cardinal;
@@ -2120,11 +2134,16 @@ begin
                      NewState := sAlmost
                   else
                      NewState := sNo;
+                  if (not SplitInHalf(Browser.Versions[VersionIndex], '-', LowVersion, HighVersion)) then
+                  begin
+                     LowVersion := Browser.Versions[VersionIndex];
+                     HighVersion := LowVersion;
+                  end;
                   if (Feature.FirstGoodVersion[BrowserIndex].Version = '') then
-                     Feature.FirstGoodVersion[BrowserIndex].LastVersion := Browser.Versions[VersionIndex];
+                     Feature.FirstGoodVersion[BrowserIndex].LastVersion := HighVersion;
                   if ((Feature.FirstGoodVersion[BrowserIndex].Version <> '') and (Feature.FirstGoodVersion[BrowserIndex].State <> NewState)) then
                      break;
-                  Feature.FirstGoodVersion[BrowserIndex].Version := Browser.Versions[VersionIndex];
+                  Feature.FirstGoodVersion[BrowserIndex].Version := LowVersion;
                   Feature.FirstGoodVersion[BrowserIndex].State := NewState;
                end;
             end;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -79,8 +79,8 @@ type
    TBug = record
       ID, URL, Summary: UTF8String;
    end;
-   TImplState = (sYes, sAlmost, sNo, sPolyfill, sUnknown, sPrefix, sDisabled, sNotes);
-   TImplGoodState = sYes..sNo;
+   TImplState = (sYes, sAlmost, sNo, sRemoved, sPolyfill, sUnknown, sPrefix, sDisabled, sNotes);
+   TImplGoodState = sYes..sRemoved;
    TVersionedState = record
       State: TImplGoodState;
       Version: UTF8String;
@@ -1022,16 +1022,14 @@ var
                               P.AppendChild(E(eSpan, ['class', Browsers[BrowserIndex].Code + ' yes'], Document,
                                               [E(eSpan, [T(Browsers[BrowserIndex].Name, Document)]),
                                                T(' '),
-                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('-'),
-                                                         T(Feature.FirstGoodVersion[BrowserIndex].LastVersion, Document)])]));
+                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('+')])]));
                            end;
                         sAlmost:
                            begin
                               P.AppendChild(E(eSpan, ['class', Browsers[BrowserIndex].Code + ' partial'], Document,
-                                              [E(eSpan, [E(eSpan, [T(Browsers[BrowserIndex].Name, Document)]),
-                                                         T(' (limited) ')]),
-                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('-'),
-                                                         T(Feature.FirstGoodVersion[BrowserIndex].LastVersion, Document)])]));
+                                              [E(eSpan, [T(Browsers[BrowserIndex].Name, Document), T(' (limited)')]),
+                                               T(' '),
+                                               E(eSpan, [T(Feature.FirstGoodVersion[BrowserIndex].Version, Document), T('+')])]));
                            end;
                         sNo:
                            begin
@@ -1039,6 +1037,13 @@ var
                                               [E(eSpan, [T(Browsers[BrowserIndex].Name, Document)]),
                                                T(' '),
                                                E(eSpan, [T('None')])]));
+                           end;
+                        sRemoved:
+                           begin
+                              P.AppendChild(E(eSpan, ['class', Browsers[BrowserIndex].Code + ' no'], Document,
+                                              [E(eSpan, [T(Browsers[BrowserIndex].Name, Document), T(' (removed)')]),
+                                               T(' '),
+                                               E(eSpan, [T('-'), T(Feature.FirstGoodVersion[BrowserIndex].LastVersion, Document)])]));
                            end;
                      end;
                end;
@@ -2140,7 +2145,11 @@ begin
                      HighVersion := LowVersion;
                   end;
                   if (Feature.FirstGoodVersion[BrowserIndex].Version = '') then
+                  begin
                      Feature.FirstGoodVersion[BrowserIndex].LastVersion := HighVersion;
+                     if ((VersionIndex <> High(Browsers[BrowserIndex].Versions)) and (NewState <> sNo)) then
+                       NewState := sRemoved;
+                  end;
                   if ((Feature.FirstGoodVersion[BrowserIndex].Version <> '') and (Feature.FirstGoodVersion[BrowserIndex].State <> NewState)) then
                      break;
                   Feature.FirstGoodVersion[BrowserIndex].Version := LowVersion;


### PR DESCRIPTION
Fixes whatwg/html#2225.

---

<img width="170" alt="caniuse-mathml" src="https://cloud.githubusercontent.com/assets/244772/21588821/c08d8d8a-d0ea-11e6-95a7-10212a24dd2b.png">

...should probably also change "5.0-5.1-10-10.1" to just "5.0-10.1", but not knowing FreePascal it's not immediately obvious to me how to do so.