### PR TITLE
Avoid % in id attributes

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -298,7 +298,7 @@ var
       for IndexSource := 1 to Length(Original) do // $R-
       begin
          case Original[IndexSource] of
-            ' ', #$0A, '<', '>', '[', #$5C, ']', '^', '{', '|', '}':
+            ' ', #$0A, '<', '>', '[', #$5C, ']', '^', '{', '|', '}', '%':
                begin
                   if (not HadSpace) then
                   begin


### PR DESCRIPTION
Since % is used for escaping in URLs, having such characters in id
can be problematic. See
https://github.com/whatwg/html/pull/2558#issuecomment-295437739

---

Diff for the %ObjProto_valueOf% link in generated output:

```diff
-   [[Value]]: <a id=the-location-interface:%objproto_valueof% href=https://tc39.github.io/ecma262/#sec-object.prototype.valueof data-x-internal=%objproto_valueof%>%ObjProto_valueOf%</a>,
+   [[Value]]: <a id=the-location-interface:objproto_valueof href=https://tc39.github.io/ecma262/#sec-object.prototype.valueof data-x-internal=objproto_valueof>%ObjProto_valueOf%</a>,
```