### PR TITLE
Error instead of warning for unused reference

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -983,7 +983,7 @@ var
                if (not References.Has(LastSeenReferenceName)) then
                begin
                   if (Variant <> vDEV) then
-                     Warn('Unused reference: [' + LastSeenReferenceName + ']');
+                     Fail('Unused reference: [' + LastSeenReferenceName + ']');
                   Result := False;
                end
             end


### PR DESCRIPTION
There should not be any unused references; error instead of warning
catches such mistakes earlier. See https://github.com/whatwg/html/pull/2987.