### PR TITLE
Do not always ensure IDs

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -554,12 +554,6 @@ var
                        'Parent of first says: "' + DFNEntry.SubDFNElement.ParentNode.TextContent.AsString + '", parent of second says: "' + Element.ParentNode.TextContent.AsString + '"');
             end;
             DFNEntry.SubDFNElement := Element;
-
-            // Need to ensure an ID because it is normally only ensured for <dfn>s or elements that
-            // are cross-referenced at least once. But subdfns can be linked to from outside, so
-            // they need an ID even if they are not referenced. Additionally, the linkage to the
-            // caniuse annotations depends on the ID existing.
-            EnsureID(Element, MungeTopicToID(CrossReferenceName));
          end;
          SectionNumber := Default(Rope);
          for CurrentHeadingRank := 2 to LastHeadingRank do


### PR DESCRIPTION
This is a partial revert of de9bac81b79ea722ede505ebf039c3e4ecb6063e.
This fixes https://github.com/whatwg/html-build/issues/121. Hopefully we
can work out something that both helps with the dev edition IDs and also
preserves IDs in the other editions, but for now, it's best to just
revert that.

This means that the dev edition will not always have IDs for the
"subdfns" included there, unless they are cross-referenced from
elsewhere. In turn, this means that the linkages to caniuse won't be
detectable in such cases.