### PR TITLE
Ensure subdfns get IDs (without stealing main IDs)

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -554,6 +554,17 @@ var
                        'Parent of first says: "' + DFNEntry.SubDFNElement.ParentNode.TextContent.AsString + '", parent of second says: "' + Element.ParentNode.TextContent.AsString + '"');
             end;
             DFNEntry.SubDFNElement := Element;
+
+            // Need to ensure an ID because it is normally only ensured for <dfn>s or elements that
+            // are cross-referenced at least once. But subdfns can be linked to from outside, so
+            // they need an ID even if they are not referenced. Additionally, the linkage to the
+            // caniuse annotations depends on the ID existing.
+            if (Variant <> vDEV) then
+               // If this isn't the dev edition, then we need to adjust the ID value to prevent the
+               // issue reported at https://github.com/whatwg/html-build/issues/121
+               EnsureID(Element, MungeTopicToID(CrossReferenceName + '-dev'))
+            else
+               EnsureID(Element, MungeTopicToID(CrossReferenceName));
          end;
          SectionNumber := Default(Rope);
          for CurrentHeadingRank := 2 to LastHeadingRank do


### PR DESCRIPTION
This change ensures that all subdfns in the dev edition get the right
IDs — as originally implemented in de9bac8, but this time by also
appending a `-dev` substring to the generated ID in the non-dev spec,
which ensures that in the non-dev edition, the subdfns don’t steal the
ID that the main non-subdfn definition needs to have. That prevents the
problem reported in https://github.com/whatwg/html-build/issues/121