### PR TITLE
Add the ability to substitute in a pubyear

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -850,35 +850,24 @@ var
             end;
          end
          else
-         if ((Element.IsIdentity(nsHTML, eSpan)) and (Element.GetAttribute('class').AsString = 'pubdate')) then
+         if ((Element.IsIdentity(nsHTML, eSpan)) and ((Element.GetAttribute('class').AsString = 'pubdate') or (Element.GetAttribute('class').AsString = 'pubyear'))) then
          begin
+            ClassName := Element.GetAttribute('class').AsString;
             if ((not Element.HasChildNodes()) or (not (Element.FirstChild is TText))) then
             begin
-               Fail('pubdate span must contain exactly one text node');
+               Fail(ClassName + ' span must contain exactly one text node');
             end
             else
             begin
                Scratch := Default(Rope);
                DecodeDate(Date, TodayYear, TodayMonth, TodayDay);
-               Scratch.Append(IntToStr(TodayDay));
-               Scratch.Append($0020);
-               Scratch.Append(@Months[TodayMonth][1], Length(Months[TodayMonth])); // $R-
-               Scratch.Append($0020);
-               Scratch.Append(IntToStr(TodayYear));
-               TText(Element.FirstChild).Data := Scratch;
-            end;
-         end
-         else
-         if ((Element.IsIdentity(nsHTML, eSpan)) and (Element.GetAttribute('class').AsString = 'pubyear')) then
-         begin
-            if ((not Element.HasChildNodes()) or (not (Element.FirstChild is TText))) then
-            begin
-               Fail('pubyear span must contain exactly one text node');
-            end
-            else
-            begin
-               Scratch := Default(Rope);
-               DecodeDate(Date, TodayYear, TodayMonth, TodayDay);
+               if(ClassName = 'pubdate') then
+               begin
+                   Scratch.Append(IntToStr(TodayDay));
+                   Scratch.Append($0020);
+                   Scratch.Append(@Months[TodayMonth][1], Length(Months[TodayMonth])); // $R-
+                   Scratch.Append($0020);
+               end;
                Scratch.Append(IntToStr(TodayYear));
                TText(Element.FirstChild).Data := Scratch;
             end;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -869,6 +869,21 @@ var
             end;
          end
          else
+         if ((Element.IsIdentity(nsHTML, eSpan)) and (Element.GetAttribute('class').AsString = 'pubyear')) then
+         begin
+            if ((not Element.HasChildNodes()) or (not (Element.FirstChild is TText))) then
+            begin
+               Fail('pubyear span must contain exactly one text node');
+            end
+            else
+            begin
+               Scratch := Default(Rope);
+               DecodeDate(Date, TodayYear, TodayMonth, TodayDay);
+               Scratch.Append(IntToStr(TodayYear));
+               TText(Element.FirstChild).Data := Scratch;
+            end;
+         end
+         else
          if (Element.IsIdentity(nsHTML, eDFN)) then
          begin
             if (Element.HasAttribute(kLTAttribute)) then


### PR DESCRIPTION
Useful for an auto-updating copyright statement.

---

This code feels suboptimal in a few ways, mainly that it duplicates the DecodeDate call with the pubdate section above it. I couldn't figure out how to deduplicate though; the scoping inside this massive function confused me too much :(. This seems good enough for now.

For the record I also tried to replace the span entirely with a new text node, but got an `EAccessViolation exception: Access violation`.