### PR TITLE
Ensure IDL blocks are omitted from the dev edition

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -2030,6 +2030,8 @@ begin
             ClassValue := Element.GetAttribute('class').AsString;
          if Element.IsIdentity(nsHTML, ePre) and (Element.TextContent.AsString = '') then
          begin
+            // This occurs because the first pass may drop <code class="idl"> elements in the dev
+            // edition, leaving empty <pre>s.
             WalkToNextSkippingChildren(Current, Document, @WalkOut);
             continue;
          end;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -647,6 +647,11 @@ var
          Element := TElement(Node);
          if (Element.HasAttribute('class')) then
             ClassValue := Element.GetAttribute('class').AsString;
+         if (IsHighlighterTarget(Element, ClassValue) and AnsiContainsStr(ClassValue, 'idl') and (Variant = vDEV)) then
+         begin
+            Result := False;
+         end
+         else
          if (Element.HasProperties(propHeading)) then
          begin
             ClassName := Element.GetAttribute('class').AsString;
@@ -972,11 +977,6 @@ var
             if (Element.HasAttribute(kLTAttribute)) then
                Fail('<code> with lt="" found, use data-x="" instead; code is ' + Describe(Element));
             SaveCrossReference(Element);
-         end
-         else
-         if (IsHighlighterTarget(Element, ClassValue) and AnsiContainsStr(ClassValue, 'idl') and (Variant = vDEV)) then
-         begin
-            Result := False;
          end
          else
          if (Element.isIdentity(nsHTML, eA) and (Element.GetAttribute('class').AsString = 'sha-link') and (Variant = vSnap)) then
@@ -2028,6 +2028,11 @@ begin
          Element := TElement(Current);
          if (Element.HasAttribute('class')) then
             ClassValue := Element.GetAttribute('class').AsString;
+         if Element.IsIdentity(nsHTML, ePre) and (Element.TextContent.AsString = '') then
+         begin
+            WalkToNextSkippingChildren(Current, Document, @WalkOut);
+            continue;
+         end;
          if (IsHighlighterTarget(Element, ClassValue)) then
          begin
             CurrentlyInHighlightedElement := True;


### PR DESCRIPTION
The existing wattsi code for causing IDL blocks to be omitted from the dev edition quit working when https://github.com/whatwg/html/pull/3768 moved class=idl attributes off `pre` elements and instead onto to `code` children of those elements,

So the first part of this change causes those `code class=idl` elements to be dropped as expected. But as a result of that, the now-empty `pre` element parents of those `code` elements are left behind. So the second part of this change looks for those empty `pre` elements and drops them.

Fixes https://github.com/whatwg/wattsi/issues/84