### PR TITLE
Allow <pre> to have <code> children w/o data-x=""

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1457,7 +1457,10 @@ begin
                   end;
                end
                else
-               if (Variant <> vDEV) then
+               if (Variant <> vDEV) and
+                  not(CrossRefNode^.Element.IsIdentity(nsHTML, eCode)
+                     and (CrossRefNode^.Element.ParentNode is TElement)
+                     and (CrossRefNode^.Element.ParentNode as TElement).IsIdentity(nsHTML, ePre)) then
                begin
                   if (CrossRefNode^.Kind = crExplicit) then
                   begin


### PR DESCRIPTION
This change allows `pre` elements to have `code` children that don’t reference a `dfn` and that don’t need to to have an explicit `data-x=""` to indicate they’re not referencing a `dfn`.

Otherwise without this change, every `code` element in the source that’s a child of a `pre` needs to have `data-x=""` — because lacking that, wattsi will emit an error for it (with the message “missing `<dfn>` for topic "foo" explicitly from `<code>` element containing "bar".”).

Fixes https://github.com/whatwg/wattsi/issues/78