### PR TITLE
Add MDN annotations to spec output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently:
  * Spec splitting
  * Add caniuse.com annotations
  * Add output for `<wpt>` elements
+ * Add MDN annotations
  * Add syntax-highlighting markup to `<pre>` contents
 
 ## Wattsi Syntax


### PR DESCRIPTION
This change adds annotations in the margin of the spec output next to any items for which there’s a corresponding MDN article somewhere under https://developer.mozilla.org/en-US/docs/Web that has a Specifications section with a link to that item's URL.

The change gives wattsi a new required command-line argument for specifying the filename of a JSON file containing a mapping of spec ID-attribute values to MDN article pathnames.

Addresses https://github.com/whatwg/html-build/issues/180