### PR TITLE
Add support for the <wpt> element

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently:
  * Strip out unused references
  * Spec splitting
  * Add caniuse.com annotations
+ * Add output for `<wpt>` elements
  * Add syntax-highlighting markup to `<pre>` contents
 
 ## Wattsi Syntax

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1855,7 +1855,7 @@ Result := False;
       WPTPath, WPTSubPath, WPTLiveURLScheme, WPTFilename: String;
       WPTPathPrefix: String = '/html/';
    begin
-      if (CurrentVariant = vDev) then
+      if ((CurrentVariant = vDev) or (CurrentVariant = vReview)) then
          exit;
       if (Element.HasAttribute('pathprefix')) then
          WPTPathPrefix := Trim(Element.GetAttribute('pathprefix').AsString);

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1860,7 +1860,9 @@ Result := False;
       if (Element.HasAttribute('pathprefix')) then
          WPTPathPrefix := Trim(Element.GetAttribute('pathprefix').AsString);
       WPTOutput := TStringList.Create;
-      WPTOutput.Add('<ul class=wpt-tests-block>');
+      WPTOutput.Add('<div class=wpt-tests-block>');
+      WPTOutput.Add('<input onclick="toggleStatus(this)" value="⋰" type="button">');
+      WPTOutput.Add('<dl>');
       WPTPaths := TStringList.Create;
       WPTPaths.Text := Element.TextContent.AsString;
       for WPTSubPath in WPTPaths do
@@ -1873,16 +1875,17 @@ Result := False;
          if (AnsiContainsStr(WPTFilename, '.https.')
                or AnsiContainsStr(WPTFilename, '.serviceworker.')) then
             WPTLiveURLScheme := 'https';
-         WPTOutput.Add('<li class=wpt-test>');
-         WPTOutput.Add('<a href="https://wpt.fyi/results'
-            + WPTPath + '">' + WPTFilename + '</a>');
-         WPTOutput.Add('<a href="' + WPTLiveURLScheme + '://web-platform-tests.live'
-            + WPTPath + '"><small>(live test)</small></a>');
-         WPTOutput.Add('<a href="https://github.com/web-platform-tests/wpt/blob/master'
-            + WPTPath + '"><small>(source)</small></a>');
-         WPTOutput.Add('</li>');
+         WPTOutput.Add('<dt>');
+         WPTOutput.Add('<a title="' + WPTFilename + '"'
+            + ' href="https://wpt.fyi/results'
+            + WPTPath + '">' + WPTFilename + '</a></dt>');
+         WPTOutput.Add('<dd><a href="' + WPTLiveURLScheme + '://web-platform-tests.live'
+            + WPTPath + '">(live test)</a>');
+         WPTOutput.Add(' <a href="https://github.com/web-platform-tests/wpt/blob/master'
+            + WPTPath + '">(source)</a></dd>');
       end;
-      WPTOutput.Add('</ul>');
+      WPTOutput.Add('</dl>');
+      WPTOutput.Add('</div>');
       Write(F, WPTOutput.Text);
    end;
 
@@ -2064,23 +2067,48 @@ begin
             Style := E(eStyle,
                [T(
 '.wpt-tests-block {'
-+ '  list-style: none;'
-+ '  border-left: .5em solid hsl(290, 70%, 60%);'
 + '  background: hsl(290, 70%, 95%);'
 + '  margin: 1em auto;'
-+ '  padding: .5em;'
-+ '  display: grid;'
-+ '  grid-template-columns: 1fr auto auto;'
-+ '  grid-column-gap: .5em;'
++ '  padding: .7em;'
++ '  width: 136px;'
++ '  font-size: 11px;'
++ '  position: absolute;'
++ '  right: 4.8px;'
++ '  z-index: 9;'
++ '  box-shadow: 0 0 3px #999'
 + '}'
-+ '.wpt-tests-block::before {'
++ '.wpt-tests-block dl::before {'
 + '  content: "Tests";'
-+ '  grid-column: 1/-1;'
 + '  color: hsl(290, 70%, 30%);'
 + '  text-transform: uppercase;'
 + '}'
-+ '.wpt-test {'
-+ '  display: contents;'
++ '.wpt-tests-block dt {'
++ '  font-weight: normal;'
++ '  overflow: hidden;'
++ '  text-overflow: ellipsis;'
++ '  margin: 0;'
++ '}'
++ '.wpt-tests-block dt:first-child {'
++ '  margin-top: 2px;'
++ '}'
++ '.wpt-tests-block dd {'
++ '  margin-left: 20px;'
++ '  line-height: 1em;'
++ '  margin-bottom: 4px;'
++ '}'
++ '.wpt-tests-block > input {'
++ '  position: absolute;'
++ '  left: 0;'
++ '  top: 0;'
++ '  width: 1em;'
++ '  height: 1em;'
++ '  border: none;'
++ '  background: transparent;'
++ '  padding: 0;'
++ '  margin: 0;'
++ '}'
++ '.wpt-tests-block.wrapped > :not(input) {'
++ '  display: none;'
 + '}'
 )]);
             Element.AppendChild(Style);

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1860,7 +1860,7 @@ Result := False;
       if (Element.HasAttribute('pathprefix')) then
          WPTPathPrefix := Trim(Element.GetAttribute('pathprefix').AsString);
       WPTOutput := TStringList.Create;
-      WPTOutput.Add('<div class=wpt-tests-block>');
+      WPTOutput.Add('<div class=wpt-tests-margin>');
       WPTOutput.Add('<input onclick="toggleStatus(this)" value="⋰" type="button">');
       WPTOutput.Add('<dl>');
       WPTPaths := TStringList.Create;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1852,7 +1852,7 @@ Result := False;
    procedure InsertWPTTestsBlock(const Element: TElement);
    var
       WPTPaths, WPTOutput: TStrings;
-      WPTPath, WPTSubPath, WPTFilename: String;
+      WPTPath, WPTSubPath, WPTLiveURLScheme, WPTFilename: String;
       WPTPathPrefix: String = '/html/';
    begin
       if (CurrentVariant = vDev) then
@@ -1865,14 +1865,18 @@ Result := False;
       WPTPaths.Text := Element.TextContent.AsString;
       for WPTSubPath in WPTPaths do
       begin
+         WPTLiveURLScheme := 'http';
          if (Trim(WPTSubPath) = '') then
             continue;
          WPTPath := WPTPathPrefix + Trim(WPTSubPath);
          WPTFilename := ExtractFileName(WPTPath);
+         if (AnsiContainsStr(WPTFilename, '.https.')
+               or AnsiContainsStr(WPTFilename, '.serviceworker.')) then
+            WPTLiveURLScheme := 'https';
          WPTOutput.Add('<li class=wpt-test>');
          WPTOutput.Add('<a href="https://wpt.fyi/results'
             + WPTPath + '">' + WPTFilename + '</a>');
-         WPTOutput.Add('<a href="http://web-platform-tests.live'
+         WPTOutput.Add('<a href="' + WPTLiveURLScheme + '://web-platform-tests.live'
             + WPTPath + '"><small>(live test)</small></a>');
          WPTOutput.Add('<a href="https://github.com/web-platform-tests/wpt/blob/master'
             + WPTPath + '"><small>(source)</small></a>');

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -2037,7 +2037,6 @@ var
    Current: TNode;
    ClassValue: String = '';
    Element: TElement;
-   Style: TElement;
 begin
    Assign(F, FileName);
    Rewrite(F);
@@ -2059,60 +2058,6 @@ begin
       if (Current is TElement) then
       begin
          Element := TElement(Current);
-         // TODO: Move the styles below to https://resources.whatwg.org/spec.css or
-         // https://resources.whatwg.org/standard.css and remove the following
-         // before merging this patch.
-         if (Element.IsIdentity(nsHTML, eHead)) then
-         begin
-            Style := E(eStyle,
-               [T(
-'.wpt-tests-block {'
-+ '  background: hsl(290, 70%, 95%);'
-+ '  margin: 1em auto;'
-+ '  padding: .7em;'
-+ '  width: 136px;'
-+ '  font-size: 11px;'
-+ '  position: absolute;'
-+ '  right: 4.8px;'
-+ '  z-index: 9;'
-+ '  box-shadow: 0 0 3px #999'
-+ '}'
-+ '.wpt-tests-block dl::before {'
-+ '  content: "Tests";'
-+ '  color: hsl(290, 70%, 30%);'
-+ '  text-transform: uppercase;'
-+ '}'
-+ '.wpt-tests-block dt {'
-+ '  font-weight: normal;'
-+ '  overflow: hidden;'
-+ '  text-overflow: ellipsis;'
-+ '  margin: 0;'
-+ '}'
-+ '.wpt-tests-block dt:first-child {'
-+ '  margin-top: 2px;'
-+ '}'
-+ '.wpt-tests-block dd {'
-+ '  margin-left: 20px;'
-+ '  line-height: 1em;'
-+ '  margin-bottom: 4px;'
-+ '}'
-+ '.wpt-tests-block > input {'
-+ '  position: absolute;'
-+ '  left: 0;'
-+ '  top: 0;'
-+ '  width: 1em;'
-+ '  height: 1em;'
-+ '  border: none;'
-+ '  background: transparent;'
-+ '  padding: 0;'
-+ '  margin: 0;'
-+ '}'
-+ '.wpt-tests-block.wrapped > :not(input) {'
-+ '  display: none;'
-+ '}'
-)]);
-            Element.AppendChild(Style);
-         end;
          if (Element.LocalName.AsString = 'wpt') then
          begin
             InsertWPTTestsBlock(Element);

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -59,6 +59,7 @@ type
 
 var
    HighlighterOutputByJSONContents: TStringMap;
+   CurrentVariant: TAllVariants;
 
 const
    kSuffixes: array[TVariants] of UTF8String = ('html', 'dev', 'snap', 'review');
@@ -1854,7 +1855,7 @@ Result := False;
       WPTPath, WPTSubPath, WPTFilename: String;
       WPTPathPrefix: String = '/html/';
    begin
-      if (InSplit) then
+      if (CurrentVariant = vDev) then
          exit;
       if (Element.HasAttribute('pathprefix')) then
          WPTPathPrefix := Trim(Element.GetAttribute('pathprefix').AsString);
@@ -2741,6 +2742,7 @@ begin
                begin
                   for Variant in TVariants do
                   begin
+                     CurrentVariant := Variant;
                      if (Variant = vReview) then
                      begin
                         continue;


### PR DESCRIPTION
This change adds support for generating output from the `<wpt>` element, as documented at https://tabatkins.github.io/bikeshed/#wpt-element) and discussed at https://github.com/tabatkins/bikeshed/issues/1116.

Specifically, this change causes lists of tests in `<wpt>` elements from the source to generate TESTS sections in the spec output, with links to corresponding https://github.com/web-platform-tests/wpt, https://wpt.fyi and https://web-platform-tests.live URLs for the listed tests.

The change by design intentionally doesn’t provide the following `<wpt>`-related features:

- Doesn’t verify that each test listed in a `<wpt>` element actually exists in https://github.com/web-platform-tests/wpt/

- Doesn’t verify that every single test file that exists in the https://github.com/web-platform-tests/wpt/tree/master/html tree is listed in a `<wpt>` element somewhere in the spec source.

Fixes https://github.com/whatwg/wattsi/issues/87