### PR TITLE
Refine handling of MDN annotations

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -791,25 +791,45 @@ var
 
       MDNBox := E(eAside, ['class', 'mdn before']);
 
-      // Find the furthest ancestor that is a direct child of <body>
-      Candidate := Element;
-      while not TElement(Candidate.ParentNode).IsIdentity(nsHTML, eBody) do
+      if (Element.HasProperties(propHeading)) then
       begin
-         Candidate := Candidate.ParentNode;
-      end;
-      TargetAncestor := TElement(Candidate);
-
-      if ((TargetAncestor.PreviousSibling is TElement)
-            and (TElement(TargetAncestor.PreviousSibling)
-               .GetAttribute('class').AsString = 'mdn before')) then
-      begin
-         // If there's already an MDN box at the point where we want this,
-         // then just re-use it (instead of creating another one).
-         MDNBox := TElement(TargetAncestor.PreviousSibling)
+         // If this is a heading, we insert the annotation after the element
+         // being annotated. When generating multipage output, inserting the
+         // annotation after the heading ensures that it ends up in the right
+         // file. It can otherwise incorrectly end up in the previous split.
+         MDNBox := E(eAside, ['class', 'mdn']);
+         if ((Element.NextSibling is TElement)
+               and ((Element.NextSibling as TElement)
+                  .GetAttribute('class').AsString = 'mdn')) then
+            // If there's already an MDN box at the point where we want this,
+            // then just re-use it (instead of creating another one).
+            MDNBox := Element.NextSibling as TElement
+         else
+            (Element.ParentNode as TElement)
+               .InsertBefore(MDNBox, Element.NextSibling);
       end
       else
       begin
-         TElement(TargetAncestor.ParentNode).InsertBefore(MDNBox, TargetAncestor);
+         // Find the furthest ancestor that is a direct child of <body>
+         Candidate := Element;
+         while not TElement(Candidate.ParentNode).IsIdentity(nsHTML, eBody) do
+         begin
+            Candidate := Candidate.ParentNode;
+         end;
+         TargetAncestor := TElement(Candidate);
+
+         if ((TargetAncestor.PreviousSibling is TElement)
+               and (TElement(TargetAncestor.PreviousSibling)
+                  .GetAttribute('class').AsString = 'mdn before')) then
+         begin
+            // If there's already an MDN box at the point where we want this,
+            // then just re-use it (instead of creating another one).
+            MDNBox := TElement(TargetAncestor.PreviousSibling)
+         end
+         else
+         begin
+            TElement(TargetAncestor.ParentNode).InsertBefore(MDNBox, TargetAncestor);
+         end;
       end;
 
       AddMDNBox(MDNBox, ID, Document);


### PR DESCRIPTION
The commits here ensure that MDN annos for headings go into right split

This commits here:

* Ensure that in multipage output, any MDN annotations headings associated with heading IDs show up in the same output file (split) as the heading.  Otherwise without this change, MDN annos for headings can end up orphaned in the previous (split) output file.

* Cause the markup for MDN annos for `p`-element-descendant elements to be inserted after the p ancestor (`</p>` end tag).  Without this change, the annos otherwise get inserted before the `p` ancestor, which is suboptimal because in many cases that results in the anno overlapping with the spec text (paragraph content) of the spec. Inserting the annos after the p ancestor minimizes the number of cases of such overlap.