### PR TITLE
Collapse MDN annotations by default

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "81") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "82") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -789,7 +789,7 @@ var
          // No MDN article has a link to this ID.
          exit;
 
-      MDNBox := E(eAside, ['class', 'mdn before']);
+      MDNBox := E(eAside, ['class', 'mdn before wrapped']);
 
       // Find the furthest ancestor that is a direct child of <body>
       Candidate := Element;


### PR DESCRIPTION
This change causes all MDN annotations in the spec to be collapsed by default. To view the contents of an annotation, users need to click on the MDN marker widget to expand the contents.

This aligns with the behavior of specs published using Respec, and on balance seems like better user experience in general. It comes with the downside of making the annotation contents less discoverable to new readers of the spec — but the tradeoff is that it prevents the cases where the spec contents are obscured by annotations (for long interface names and such), and overall makes the spec pages less cluttered and more readable.

Fixes https://github.com/whatwg/html/issues/4635
Relates to https://github.com/whatwg/html/issues/4236