### PR TITLE
Fail if the highlighter responds with 400 status

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "82") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "83") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -2180,6 +2180,8 @@ Result := False;
       URLEncodedJSONContents: String;
       HighlighterOutput: String;
       ClassValue: String = '';
+      HTTPClient: TFPHTTPClient;
+      Ss: TStringStream;
    begin
       // The following causes the </pre> end tag for any empty pre elements to
       // be dropped. We can end up with empty pre elements because the first
@@ -2207,22 +2209,35 @@ Result := False;
                   Write(F, HighlighterOutputByJSONContents[CurrentHighlightedElementJSON])
                else
                begin
-                  if (AnsiContainsStr(ClassValue, 'idl')) then
-                     HighlighterOutput := TFPCustomHTTPClient.SimpleGet(HighlightServerURL + '/webidl?' + URLEncodedJSONContents)
-                  else
-                  if (AnsiContainsStr(ClassValue, 'css')) then
-                     HighlighterOutput := TFPCustomHTTPClient.SimpleGet(HighlightServerURL + '/css?' + URLEncodedJSONContents)
-                  else
-                  if (AnsiContainsStr(ClassValue, 'js')) then
-                     HighlighterOutput := TFPCustomHTTPClient.SimpleGet(HighlightServerURL + '/js?' + URLEncodedJSONContents)
-                  else
-                  if (AnsiContainsStr(ClassValue, 'abnf')) then
-                     HighlighterOutput := TFPCustomHTTPClient.SimpleGet(HighlightServerURL + '/abnf?' + URLEncodedJSONContents)
-                  else
-                  if (AnsiContainsStr(ClassValue, 'html')) then
-                     HighlighterOutput := TFPCustomHTTPClient.SimpleGet(HighlightServerURL + '/html?' + URLEncodedJSONContents);
-                  HighlighterOutputByJSONContents[CurrentHighlightedElementJSON] := HighlighterOutput;
-                  Write(F, Trim(HighlighterOutput));
+                  try
+                     HTTPClient := TFPHTTPClient.Create(nil);
+                     Ss := TStringStream.Create('');
+                     if (AnsiContainsStr(ClassValue, 'idl')) then
+                        HTTPClient.HTTPMethod('GET', HighlightServerURL + '/webidl?' + URLEncodedJSONContents, Ss, [200,400])
+                     else
+                     if (AnsiContainsStr(ClassValue, 'css')) then
+                        HTTPClient.HTTPMethod('GET', HighlightServerURL + '/css?' + URLEncodedJSONContents, Ss, [200,400])
+                     else
+                     if (AnsiContainsStr(ClassValue, 'js')) then
+                        HTTPClient.HTTPMethod('GET', HighlightServerURL + '/js?' + URLEncodedJSONContents, Ss, [200,400])
+                     else
+                     if (AnsiContainsStr(ClassValue, 'abnf')) then
+                        HTTPClient.HTTPMethod('GET', HighlightServerURL + '/abnf?' + URLEncodedJSONContents, Ss, [200,400])
+                     else
+                     if (AnsiContainsStr(ClassValue, 'html')) then
+                        HTTPClient.HTTPMethod('GET', HighlightServerURL + '/html?' + URLEncodedJSONContents, Ss, [200,400]);
+                     HighlighterOutput := Ss.Datastring;
+                     Ss.Free;
+                     if HTTPClient.ResponseStatusCode = 400 then
+                     begin
+                        Write(Trim(HighlighterOutput));
+                        Halt(1);
+                     end;
+                     HighlighterOutputByJSONContents[CurrentHighlightedElementJSON] := HighlighterOutput;
+                     Write(F, Trim(HighlighterOutput));
+                  finally
+                     HTTPClient.Free;
+                  end;
                end;
             except
               on E: EHTTPClient do


### PR DESCRIPTION
This change causes wattsi to stop if it receives an HTTP response from the highlighter with a 400 status code.

Relates to https://github.com/whatwg/html-build/issues/201 (“Build does not fail on invalid Web IDL”)

---

This doesn’t work yet in practice for what we actually need it for, which is to make the build fail for invalid Web IDL, as reported in https://github.com/whatwg/html-build/issues/201.

The reason it doesn’t work in practice is that, as far I can tell, the highlighter doesn’t actually respond with a 400 when it encounters a Web IDL syntax error. See https://github.com/tabatkins/highlighter/issues/14.