### PR TITLE
Add nil check for mdn-spec-links JSON support data

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "83") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "84") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -270,14 +270,14 @@ begin
             Document, [T(MDNSubpath, Document)])]));
       MDNDiv.AppendChild(MDNDetails);
       MDNBox.AppendChild(MDNDiv);
-      if (MDNData.Length = 3) then
+      MDNSupport := MDNData['support'];
+      if (MDNSupport = nil) then
       begin
          SupportTable := E(eP, ['class', 'nosupportdata']);
          SupportTable.AppendChild(T('No support data.'));
          MDNDetails.AppendChild(SupportTable);
          continue;
       end;
-      MDNSupport := MDNData['support'];
       SupportTable := E(eP, ['class', 'mdnsupport']);
       MDNDetails.AppendChild(SupportTable);
       for i := 0 to MDNBrowsers.Count - 1 do


### PR DESCRIPTION
This change causes Wattsi to nil(null)-check the "support" object from the imported mdn-spec-links JSON data before trying to perform any operations with the object.

Without this change, if the "support" object’s value is null in the imported mdn-spec-links JSON data, wattsi crashes.

---

This change un-breaks the HTML spec build. (I had broken it with some changes I made to how the https://raw.githubusercontent.com/w3c/mdn-spec-links/master/html.json file gets generated.)