### PR TITLE
MDN annos: Split out "Edge (Legacy)" from Edge

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "84") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "85") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -173,7 +173,13 @@ begin
    YNULowercase := LowerCase(YesNoUnknown);
    if (YNU = 'Unknown') then
       YNU := '?';
-   BrowserRow := E(eSpan, ['class', BrowserID + ' ' + YNULowercase], Document);
+   if (BrowserID = 'edge_blink') then
+      BrowserRow := E(eSpan, ['class', 'edge ' + YNULowercase], Document)
+   else
+   if (BrowserID = 'edge') then
+      BrowserRow := E(eSpan, ['class', 'edge_legacy ' + YNULowercase], Document)
+   else
+      BrowserRow := E(eSpan, ['class', BrowserID + ' ' + YNULowercase], Document);
    BrowserRow.AppendChild(E(eSpan, [T(MDNBrowsers[BrowserID], Document)]));
    if (Version = '') then
       BrowserRow.AppendChild(E(eSpan, [T(YNU, Document)]))
@@ -2891,7 +2897,8 @@ begin
       // See the list of browser IDs at https://goo.gl/iDacWP.
       MDNBrowsers['chrome'] := 'Chrome';
       MDNBrowsers['chrome_android'] := 'Chrome Android';
-      MDNBrowsers['edge'] := 'Edge';
+      MDNBrowsers['edge_blink'] := 'Edge';
+      MDNBrowsers['edge'] := 'Edge (Legacy)';
       MDNBrowsers['edge_mobile'] := 'Edge Mobile';
       MDNBrowsers['firefox'] := 'Firefox';
       MDNBrowsers['firefox_android'] := 'Firefox Android';


### PR DESCRIPTION
This change updates the support/compat sections of the MDN annotations to add an "Edge (Legacy)" row, in addition to the existing "Edge" row (which now shows data for current Blink-based Edge).