### PR TITLE
MDN annos: Mark flag-needed features w/ indicator; fix underlying algorithm

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "86") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "87") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"


### PR DESCRIPTION
In the MDN annotations, this change adds an indicator symbol within the version-number column in any cell for a browser whose implementation of the associated feature isn’t exposed by default but instead requires setting a user preference or runtime flag.

This change also rewrites the underlying algorithm for determining from the BCD data whether a particular browser supports a given feature — to fix a fundamental problem in the existing code which causes it to, in some cases, wrongly add multiple rows for some browsers to the support tables in the MDN annotations, with different version numbers and different/ conflicting indications of whether the browser supports the feature.