### PR TITLE
MDN annos: Show less-than-2/all-engines indicators

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "87") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "88") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"


### PR DESCRIPTION
This change adds indicator symbols and text in the MDN annotations, to give information about the number of browser engines which support the feature associated with the annotation.