### PR TITLE
Fix MDN annotations on the single page spec

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "88") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "89") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"


### PR DESCRIPTION
#95 regressed some of the annotations in the singlepage spec, as the location the annotation-inserting code was moved to no longer supported inserting before the element. This commit makes the InsertMDNAnnotationForElement procedure called twice, once when it is safe to insert nodes before, and once when it is safe to insert nodes after, so that it can insert as appropriate.