### PR TITLE
Ensure MDN annos for headings go into right split (revisited)

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "88") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "89") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -904,6 +904,45 @@ var
       end;
    end;
 
+   procedure InsertMDNAnnotationForElement(const Element: TElement);
+   var
+      Candidate: TNode;
+      ID: UTF8String;
+      TargetAncestor, MDNBox: TElement;
+   begin
+      if (not(Element.HasAttribute('id'))) then
+         exit;
+      ID := Element.GetAttribute('id').AsString;
+      if (not(MDNJSONData[ID] is TJSONArray)) then
+         // No MDN article has a link to this ID.
+         exit;
+
+      MDNBox := E(eAside, ['class', 'mdn before wrapped']);
+
+      // Find the furthest ancestor that is a direct child of <body>
+      Candidate := Element;
+      while not TElement(Candidate.ParentNode).IsIdentity(nsHTML, eBody) do
+      begin
+         Candidate := Candidate.ParentNode;
+      end;
+      TargetAncestor := TElement(Candidate);
+
+      if ((TargetAncestor.PreviousSibling is TElement)
+            and (TElement(TargetAncestor.PreviousSibling)
+               .GetAttribute('class').AsString = 'mdn before')) then
+      begin
+         // If there's already an MDN box at the point where we want this,
+         // then just re-use it (instead of creating another one).
+         MDNBox := TElement(TargetAncestor.PreviousSibling)
+      end
+      else
+      begin
+         TElement(TargetAncestor.ParentNode).InsertBefore(MDNBox, TargetAncestor);
+      end;
+
+      AddMDNBox(MDNBox, ID, Document);
+   end;
+
    function ProcessNode(var Node: TNode): Boolean; // return True if we are to keep this node, False if we drop it
    const
       CommitSnapshotBaseURL: AnsiString = '/commit-snapshots/';
@@ -1423,6 +1462,8 @@ var
 
    procedure ProcessNodeExit(const Node: TElement);
    begin
+      if (Variant <> vReview) then
+         InsertMDNAnnotationForElement(Node);
       if (Node = InHeading) then
          InHeading := nil
       else
@@ -2183,61 +2224,6 @@ Result := False;
       Write(F, WPTOutput.Text);
    end;
 
-   procedure InsertMDNAnnotationForElement(const Element: TElement);
-   var
-      ID, ClassName: UTF8String;
-      MDNBox, PotentialExistingBox: TElement;
-      InsertBeforeLocation: TNode;
-   begin
-      if ((CurrentVariant = vHTML) and InSplit) then
-         // MDN annotations have already been inserted in this case.
-         exit;
-      if (not(Element.HasAttribute('id'))) then
-         exit;
-      ID := Element.GetAttribute('id').AsString;
-      if (not(MDNJSONData[ID] is TJSONArray)) then
-         // No MDN article has a link to this ID.
-         exit;
-
-      MDNBox := E(eAside);
-
-      // Find the furthest ancestor that is a direct child of <body>
-      InsertBeforeLocation := Element;
-      while not TElement(InsertBeforeLocation.ParentNode).IsIdentity(nsHTML, eBody) do
-      begin
-         InsertBeforeLocation := InsertBeforeLocation.ParentNode;
-      end;
-
-      // For <p>s and headings, we want to insert after that ancestor:
-      // - For <p>s, we want to avoid overlapping the <p> contents.
-      // - For headings, we need to ensure that on any multipage splits, we end up in the correct file.
-      ClassName := 'mdn before wrapped';
-      PotentialExistingBox := InsertBeforeLocation.PreviousElementSibling();
-      if (TElement(InsertBeforeLocation).HasProperties(propHeading) or
-          TElement(InsertBeforeLocation).isIdentity(nsHTML, eP)) then
-      begin
-         ClassName := 'mdn wrapped';
-         PotentialExistingBox := InsertBeforeLocation.NextElementSibling();
-         InsertBeforeLocation := InsertBeforeLocation.NextSibling;
-      end;
-
-      // If there's already an MDN box at the point where we want this,
-      // then just re-use it (instead of creating another one).
-      if (Assigned(PotentialExistingBox) and
-          ((PotentialExistingBox.GetAttribute('class').AsString = 'mdn wrapped') or
-           (PotentialExistingBox.GetAttribute('class').AsString = 'mdn before wrapped'))) then
-      begin
-         MDNBox := PotentialExistingBox
-      end
-      else
-      begin
-         MDNBox.SetAttribute('class', ClassName);
-         TElement(InsertBeforeLocation.ParentNode).InsertBefore(MDNBox, InsertBeforeLocation);
-      end;
-
-      AddMDNBox(MDNBox, ID, Document);
-   end;
-
    procedure WalkIn(const Element: TElement);
    var
       IsExcluder, Skip, NotFirstAttribute: Boolean;
@@ -2391,8 +2377,6 @@ Result := False;
             CurrentlyInHighlightedElement := False;
          end;
       end;
-      if (CurrentVariant <> vReview) then
-         InsertMDNAnnotationForElement(Element);
       if (Element.ParentNode is TElement) then
          CurrentElement := TElement(Element.ParentNode)
       else


### PR DESCRIPTION
This PR is an alternative to #112 that just solves the same single *“Ensure MDN annos for headings go into right split”* problem we originally set out to solve in #94 and #95 — but without trying to solve the separate *“avoid having annos end up overlapping with paragraph text”* issue.

The *“avoid having annos end up overlapping with paragraph text”* issue is no longer a problem in practice, because we now minimize the annos by default — so the annos don’t overlap unless expanded, and then users can just unexpand/re-minimize them to view any text they overlap.

This branch has two commits:

* fb3b0dd, which is a revert of the 2deef18 commit we merged to master from #95 
* d441d64, which is a slightly-modified version of 68e817e (the part of #94 that addressed just the *“Ensure MDN annos for headings go into right split”* problem)

With the approach in this PR:

* we only need to call `InsertMDNAnnotationForElement`  once, within `ProcessNodeExit`
* we don’t have any cases of some annos still not getting output — all get output as expected 
