### PR TITLE
MDN annos: Align with Bikeshed-generated markup and styles; other refinements

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -243,12 +243,6 @@ begin
                                 Document);
                exit;
             end;
-            if (VersionDetails['version_added'] = nil) then
-            begin
-               AddMDNBrowserRow(SupportTable, BrowserID, 'Unknown', '',
-                                NeedsFlag, Document);
-               exit;
-            end;
             AddMDNBrowserRow(SupportTable, BrowserID, 'Yes',
                              UTF8String(VersionDetails['version_added']) + '+',
                              NeedsFlag, Document);
@@ -290,17 +284,13 @@ begin
                                 Document);
                exit;
             end;
-            if (VersionData['version_added'] = nil) then
-            begin
-               AddMDNBrowserRow(SupportTable, BrowserID, 'Unknown', '',
-                                NeedsFlag, Document);
-               exit;
-            end;
             AddMDNBrowserRow(SupportTable, BrowserID, 'Yes',
                              UTF8String(VersionData['version_added']) +
                              '+', NeedsFlag, Document);
             exit;
          end;
+         AddMDNBrowserRow(SupportTable, BrowserID, 'Unknown', '',
+                          NeedsFlag, Document);
       end;
    end;
 end;


### PR DESCRIPTION
This change aligns the Wattsi-generated MDN-anno markup and classnames with those that Bikeshed outputs. That allows us to use the same styles in https://resources.whatwg.org/standard-shared-with-dev.css for both all WHATWG Bikeshed-generated standards and for the HTML standard. So this depends on whatwg/whatwg.org#311.

*“Reorder browser lists into groups”* 8151408 is an additional commit in this branch, to cause the browser ordering in MDN annos to match the same ordering that Bikeshed outputs.

The branch in this PR also includes two other commits with MDN-anno refinements:

* Show removed-feature version ranges 8700d45
* Handle nonconforming support cases 20cf86b

…so this PR may be easier to review if the commits in this branch are reviewed individually (rather than reviewing the diff for all of the changes together).

But if it’s preferable to have the later commits split out into separate PRs, we can do that instead.