### PR TITLE
MDN annos: Fix placement of annos in tables/lists

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -21,7 +21,7 @@ DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 echo "Writing $VERSION_FILE"
 # If you update the fallback below also update WATTSI_LATEST in
 # https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "90") > "$VERSION_FILE"
+(git rev-list --count HEAD || echo "91") > "$VERSION_FILE"
 . ${SRC}lib/compile.sh
 echo "Removing $VERSION_FILE"
 rm "$VERSION_FILE"

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1036,6 +1036,34 @@ var
          end
       end
       else
+      if (HasAncestor(Element, nsHTML, eTD) or HasAncestor(Element, nsHTML, eDT)) then
+      begin
+         // For elements we're annotating inside a <td> or <dt>, we append the
+         // annotation directly to the <td> or <dt> as the last child. Otherwise
+         // in cases where we have a long table (e.g., the list of events in the
+         // index) or long <dl> list (e.g., the list of pseudo-classes), all the
+         // annos for everything in that table or list end up being merged into
+         // a single annotation way up at the beginning of the table or list.
+         ClassName := 'mdn-anno wrapped before';
+         Candidate := Element;
+         while not TElement(Candidate).IsIdentity(nsHTML, eTD) and
+               not TElement(Candidate).IsIdentity(nsHTML, eDT) do
+            Candidate := Candidate.ParentNode;
+         TargetAncestor := TElement(Candidate);
+         if (TargetAncestor.LastElementChild().GetAttribute('class').AsString = ClassName) then
+         begin
+            // If there's already an MDN box at the point where we want this,
+            // then just re-use it (instead of creating another one).
+            MDNBox := TargetAncestor.LastElementChild();
+            IsFirst := False;
+         end
+         else
+         begin
+            TargetAncestor.AppendChild(MDNBox);
+            IsFirst := True;
+         end;
+      end
+      else
       begin
          ClassName := 'mdn-anno wrapped before';
 

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -189,24 +189,25 @@ begin
    BrowserClass := BrowserID + ' ' + YesNoUnknown;
    FlagSymbol := '';
    BrowserVersionAttributes := Default(AttributesArray);
+   BrowserVersionAttributes := AttributesArray.Create('data-x', '');
    if (IsPartial or NeedsFlag or NeedsPrefixOrAltName) then
       FlagSymbol := UTF8String(#$F0#$9F#$94#$B0) + ' ';
    if (NeedsPrefixOrAltName) then
       BrowserVersionAttributes := AttributesArray
-        .Create('title', 'Requires a prefix or alternative name.');
+        .Create('data-x', '', 'title', 'Requires a prefix or alternative name.');
    if (NeedsFlag) then
       BrowserVersionAttributes := AttributesArray
-        .Create('title', 'Requires setting a user preference or runtime flag.');
+        .Create('data-x', '', 'title', 'Requires setting a user preference or runtime flag.');
    if (IsPartial) then
       BrowserVersionAttributes := AttributesArray
-        .Create('title', 'Partial implementation.');
+        .Create('data-x', '', 'title', 'Partial implementation.');
    if (BrowserID = 'edge_blink') then
       BrowserClass := 'edge_blink ' + YesNoUnknown
    else
    if (BrowserID = 'edge') then
       BrowserClass := 'edge ' + YesNoUnknown;
-   BrowserRow := E(eSpan, ['class', BrowserClass], Document);
-   BrowserRow.AppendChild(E(eSpan, [T(MDNBrowsers[BrowserID], Document)]));
+   BrowserRow := E(eSpan, ['data-x', '', 'class', BrowserClass], Document);
+   BrowserRow.AppendChild(E(eSpan, ['data-x', ''], [T(MDNBrowsers[BrowserID], Document)]));
    BrowserRow.AppendChild(E(eSpan, BrowserVersionAttributes,
                              [T(FlagSymbol + Version, Document)]));
    SupportTable.AppendChild(BrowserRow);
@@ -449,7 +450,7 @@ begin
          if ((EngineCount <> 2) and (MDNSupport <> nil)) then
             MDNButton.AppendChild(E(eB, ['class', FlagClassName,
                   'title', FlagTitle], Document, [T(FlagSymbol, Document)]));
-         MDNButton.AppendChild(E(eSpan, [T('MDN')]));
+         MDNButton.AppendChild(E(eSpan, ['data-x', ''], [T('MDN')]));
          MDNBox.AppendChild(MDNButton);
       end;
       IsFirst := False;


### PR DESCRIPTION
This change ensures that for elements we’re annotating which are inside tables or lists, each anno ends up placed as expected in horizontal alignment with the element it’s annotating.

Otherwise, without this change, in cases where we have a long table (e.g., the list of events in the index) or long `<dl>` list (e.g., the list of pseudo-classes), all the annos for everything in that table or list end up being merged into a single annotation way up at the beginning of the table or list — which prevents them from being discoverable to readers.

Depends on https://github.com/whatwg/whatwg.org/pull/314

---
https://html-mdn.herokuapp.com/output/ has the output from this; see in particular:

* https://html-mdn.herokuapp.com/output/multipage/semantics-other.html#pseudo-classes
* https://html-mdn.herokuapp.com/output/multipage/indices.html#events-2

Diff is at https://github.com/whatwg/html-build/commit/4998e09a8d5487fea4df8f45a5f5cd12e3a2857d#diff-3b01d824450e992ce224a09eb08548b5