### PR TITLE
Build and deploy Wattsi on CI using Docker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.pas]
+indent_size = 3
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+src/version.inc

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,12 @@ deploy:
   script: docker push "$IMAGE_NAME:latest" && docker push "$IMAGE_NAME:$VERSION"
   on:
     branch: master
+
+branches:
+  only:
+    - master
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: bash
+services:
+  - docker
+
+git:
+  depth: false
+
+env:
+  global:
+    - IMAGE_NAME=whatwg/wattsi
+    - DOCKER_USERNAME=domenicdenicola
+    - secure: "gXc7fg5eVsFk//Lxt8clbPwrYKecbUZ21wx1cGCBBPuJ4GYbbIGMiOd3RimYP0iOa2UaKgXtiyi9midB5fs2Xiw2O3C5l1VLvRn7JGHQD3KaFi6bfofmmygdg7VT9KFgvxLsPCde3ZtYLvc8s/VSYSrwIEOe2mhC7iUg4tkC7E2aFK0y3ElqQk7fQTcMXX4KE+pGS5EJ75qgHA5Js/W0x2bz/Cl3onIINC5B/8RWCKIEmfRu/4hKJABv98km+zB5WCmuFZSGzbP1F5gCU9qg9EIgP0na8B7mjRiZ3WkpfAFSrPtVTkaDVnKTKeriiWIsLt6lOClZKFr5iocg8rFuKj6RrST0MFSmGJvJByWVoiMwHVmEZv3vX39IIUEQDiH7GEv8Q5R5P6hHbRnSCN5nGNoylcFAAi4dELpgEqRrJEoLvURxfSthZJUNRKoLm0zhECxuUggJEqseG1GCzYlob3efaGwDmJONeazjJcX3IDPs/oX8bf4HqkyoZcAvOHKzPof6EzNNGdlSXL0TXsET2SRVB7y8hlypI6xJ5l1HGfALZDb6bYwFvjmzSoXcHcY1jU4w8HUUm7VBbGBy1Mu0WHeYE4dsjOuOp8lSf2eFd5L1Y2FaJfMt3TWe7uNEIPLzglwX3T1QuaaVpSKAB0BQ/VY8/OjLe1wXb6NlsF+HBnA="
+
+before_script:
+  - VERSION="$(git rev-list --count HEAD)"
+  - echo "$VERSION" > src/version.inc
+  - docker pull "$IMAGE_NAME" || true
+script:
+  - docker build --pull --cache-from "$IMAGE_NAME" --tag "$IMAGE_NAME" .
+after_script:
+  - docker images
+  - docker run "$IMAGE_NAME"
+
+before_deploy:
+  - docker login -u "$DOCKER_USERNAME" "$DOCKER_PASSWORD"
+  - docker tag "$IMAGE_NAME" "$IMAGE_NAME:latest"
+  - docker tag "$IMAGE_NAME" "$IMAGE_NAME:$VERSION"
+deploy:
+  provider: script
+  script: docker push "$IMAGE_NAME:latest" && docker push "$IMAGE_NAME:$VERSION"
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,14 @@ env:
     - DOCKER_USERNAME=domenicdenicola
     - secure: "gXc7fg5eVsFk//Lxt8clbPwrYKecbUZ21wx1cGCBBPuJ4GYbbIGMiOd3RimYP0iOa2UaKgXtiyi9midB5fs2Xiw2O3C5l1VLvRn7JGHQD3KaFi6bfofmmygdg7VT9KFgvxLsPCde3ZtYLvc8s/VSYSrwIEOe2mhC7iUg4tkC7E2aFK0y3ElqQk7fQTcMXX4KE+pGS5EJ75qgHA5Js/W0x2bz/Cl3onIINC5B/8RWCKIEmfRu/4hKJABv98km+zB5WCmuFZSGzbP1F5gCU9qg9EIgP0na8B7mjRiZ3WkpfAFSrPtVTkaDVnKTKeriiWIsLt6lOClZKFr5iocg8rFuKj6RrST0MFSmGJvJByWVoiMwHVmEZv3vX39IIUEQDiH7GEv8Q5R5P6hHbRnSCN5nGNoylcFAAi4dELpgEqRrJEoLvURxfSthZJUNRKoLm0zhECxuUggJEqseG1GCzYlob3efaGwDmJONeazjJcX3IDPs/oX8bf4HqkyoZcAvOHKzPof6EzNNGdlSXL0TXsET2SRVB7y8hlypI6xJ5l1HGfALZDb6bYwFvjmzSoXcHcY1jU4w8HUUm7VBbGBy1Mu0WHeYE4dsjOuOp8lSf2eFd5L1Y2FaJfMt3TWe7uNEIPLzglwX3T1QuaaVpSKAB0BQ/VY8/OjLe1wXb6NlsF+HBnA="
 
-before_script:
-  - VERSION="$(git rev-list --count HEAD)"
-  - echo "$VERSION" > src/version.inc
-  - docker pull "$IMAGE_NAME" || true
 script:
-  - docker build --pull --cache-from "$IMAGE_NAME" --tag "$IMAGE_NAME" .
+  - make docker
 after_script:
   - docker images
-  - docker run "$IMAGE_NAME"
+  - docker run "$IMAGE_NAME" --version
 
 before_deploy:
+  - VERSION="$(cat src/version.inc)"
   - docker login -u "$DOCKER_USERNAME" "$DOCKER_PASSWORD"
   - docker tag "$IMAGE_NAME" "$IMAGE_NAME:latest"
   - docker tag "$IMAGE_NAME" "$IMAGE_NAME:$VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,12 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends fp-compiler fp-units-fcl fp-units-net libc6-dev
 
 COPY src /whatwg/wattsi/src
-RUN mkdir -p /whatwg/wattsi/bin
 
 WORKDIR /whatwg/wattsi/src
 RUN ./build.sh
 
-RUN rm -rf /whatwg/wattsi/src
-RUN apt-get purge -y fp-compiler fp-units-fcl fp-units-net libc6-dev && \
+RUN rm -rf /whatwg/wattsi/src && \
+    apt-get purge -y fp-compiler fp-units-fcl fp-units-net libc6-dev && \
     apt-get autoremove -y
 
 ENTRYPOINT ["/whatwg/wattsi/bin/wattsi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ WORKDIR /whatwg/wattsi/src
 RUN ./build.sh
 
 RUN rm -rf /whatwg/wattsi/src
-RUN apt-get purge -y fp-compiler fp-units-fcl fp-units-net && \
+RUN apt-get purge -y fp-compiler fp-units-fcl fp-units-net libc6-dev && \
     apt-get autoremove -y
 
 ENTRYPOINT ["/whatwg/wattsi/bin/wattsi"]
-CMD ["--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM debian:stable-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends fp-compiler fp-units-fcl fp-units-net libc6-dev
-
 COPY src /whatwg/wattsi/src
-
 WORKDIR /whatwg/wattsi/src
-RUN ./build.sh
 
-RUN rm -rf /whatwg/wattsi/src && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends fp-compiler fp-units-fcl fp-units-net libc6-dev && \
+    ./build.sh && \
+    rm -rf /whatwg/wattsi/src && \
+    mv /whatwg/wattsi/bin/wattsi /whatwg/wattsi/wattsi && \
+    rm -rf /whatwg/wattsi/bin && \
     apt-get purge -y fp-compiler fp-units-fcl fp-units-net libc6-dev && \
     apt-get autoremove -y
 
-ENTRYPOINT ["/whatwg/wattsi/bin/wattsi"]
+ENTRYPOINT ["/whatwg/wattsi/wattsi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stable-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends fp-compiler fp-units-fcl fp-units-net libc6-dev
+
+COPY src /whatwg/wattsi/src
+RUN mkdir -p /whatwg/wattsi/bin
+
+WORKDIR /whatwg/wattsi/src
+RUN ./build.sh
+
+RUN rm -rf /whatwg/wattsi/src
+RUN apt-get purge -y fp-compiler fp-units-fcl fp-units-net && \
+    apt-get autoremove -y
+
+ENTRYPOINT ["/whatwg/wattsi/bin/wattsi"]
+CMD ["--version"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SHELL=/bin/bash -o pipefail
+.PHONY: clean docker manual
+
+clean:
+	rm -rf src/version.inc
+	rm -rf bin/
+
+docker:
+	git rev-list --count HEAD > src/version.inc
+	docker pull whatwg/wattsi || true
+	docker build --pull --cache-from whatwg/wattsi --tag whatwg/wattsi .
+
+manual:
+	mkdir -p bin
+	cd src
+	bash ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,4 @@ docker:
 	docker build --pull --cache-from whatwg/wattsi --tag whatwg/wattsi .
 
 manual:
-	mkdir -p bin
-	cd src
-	bash ./build.sh
+	bash ./src/build.sh

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ For documentation on the "Wattsi language", e.g. things like `data-x` or `w-node
 
 ## Building and running Wattsi with Docker
 
-The easiest way to use Wattsi is via [Docker](https://www.docker.com/). Once you have Docker, you can run Wattsi using
+The easiest way to use Wattsi is via [Docker](https://www.docker.com/). Once you have Docker, you can download and run a copy of Wattsi from [Docker Hub](https://hub.docker.com/u/whatwg/wattsi) using
 
-```
+```bash
 docker run whatwg/wattsi
 ```
 
 The [HTML build tools](https://github.com/whatwg/html-build) will automatically attempt to use this form if they cannot find a locally-installed copy of Wattsi.
 
-If you're developing Wattsi, you can build and test it in Docker with the commands `docker build . --tag whatwg/wattsi` and `docker run whatwg/wattsi`. The latter accepts any Wattsi arguments, e.g. `docker run whatwg/wattsi --version`.
+If you're developing Wattsi, you can build and test it in Docker with the command `make docker` and `docker run whatwg/wattsi`. The latter accepts any Wattsi arguments, e.g. `docker run whatwg/wattsi --version`.
 
 ## Building and running Wattsi manually
 
-With the [Free Pascal Compiler (fpc)](https://www.freepascal.org/) installed, you should be able to run `./build.sh` to create the `wattsi` executable and supporting shared libraries.
+With the [Free Pascal Compiler (fpc)](https://www.freepascal.org/) installed, you should be able to run `make manual` to create the `wattsi` executable and supporting shared libraries.
 
 The `wattsi` executable is at `./bin/wattsi`. Tools such as `html-build` use `$PATH` to look for a local `wattsi` executable. In your terminal, run `export PATH=$PATH:$(pwd)/bin`. In the same terminal tab, you can now run tools that use the built `wattsi` executable.
 
@@ -50,7 +50,7 @@ Wattsi is written in [Free Pascal](https://www.freepascal.org/), so to build Wat
 
 On Debian and Ubuntu and any other Debian-derived systems, run `apt install` to install the necessary packages:
 
-```
+```bash
 apt install fp-compiler fp-units-fcl fp-units-net libc6-dev
 ```
 
@@ -58,7 +58,7 @@ apt install fp-compiler fp-units-fcl fp-units-net libc6-dev
 
 On macOS, install [Homebrew](https://brew.sh/) and the homebrew fpc 3.0.4 *revision 1* (3.0.4_1) or later package. The *revision 1* there is important — the initial 3.0.4 package will not work as expected on macOS Mojave (10.14) or later.
 
-```
+```bash
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install fpc
 ```
@@ -75,6 +75,6 @@ On macOS, you may also need to have [XCode](https://developer.apple.com/xcode/) 
 
 If you already have XCode installed, you can ensure you have the latest XCode command-line tools by running the following command:
 
-```
+```bash
 xcode-select --install
 ```

--- a/README.md
+++ b/README.md
@@ -18,11 +18,23 @@ Currently:
  * Add MDN annotations
  * Add syntax-highlighting markup to `<pre>` contents
 
-## Wattsi Syntax
+## Wattsi syntax
 
 For documentation on the "Wattsi language", e.g. things like `data-x` or `w-nodev`, see [Syntax.md](./Syntax.md).
 
-## Building Wattsi
+## Building and running Wattsi with Docker
+
+The easiest way to use Wattsi is via [Docker](https://www.docker.com/). Once you have Docker, you can run Wattsi using
+
+```
+docker run whatwg/wattsi
+```
+
+The [HTML build tools](https://github.com/whatwg/html-build) will automatically attempt to use this form if they cannot find a locally-installed copy of Wattsi.
+
+If you're developing Wattsi, you can build and test it in Docker with the commands `docker build . --tag whatwg/wattsi` and `docker run whatwg/wattsi`. The latter accepts any Wattsi arguments, e.g. `docker run whatwg/wattsi --version`.
+
+## Building and running Wattsi manually
 
 With the [Free Pascal Compiler (fpc)](https://www.freepascal.org/) installed, you should be able to run `./build.sh` to create the `wattsi` executable and supporting shared libraries.
 
@@ -30,13 +42,11 @@ The `wattsi` executable is at `./bin/wattsi`. Tools such as `html-build` use `$P
 
 For guidance on installing fpc, see the next section.
 
-We hope to in the future provide precompiled wattsi binaries, built via continuous integration, for Wattsi. If you think you can help with this, please file an issue to get the discussion started! In the meantime, we do provide the [wattsi-server](https://github.com/domenic/wattsi-server) service, which allows you to upload files to a server that will run Wattsi for you.
-
-## Installing the Free Pascal Compiler (fpc)
+### Installing the Free Pascal Compiler (fpc)
 
 Wattsi is written in [Free Pascal](https://www.freepascal.org/), so to build Wattsi, you'll need version 3.0.4 or later of the Free Pascal Compiler (fpc). You can get fpc by [downloading a freepascal.org upstream release](https://www.freepascal.org/download.var) — but it’s recommended that you instead install fpc using a package manager.
 
-### Installing fpc on Debian and Ubuntu
+#### Installing fpc on Debian and Ubuntu
 
 On Debian and Ubuntu and any other Debian-derived systems, run `apt install` to install the necessary packages:
 
@@ -44,22 +54,22 @@ On Debian and Ubuntu and any other Debian-derived systems, run `apt install` to 
 apt install fp-compiler fp-units-fcl fp-units-net libc6-dev
 ```
 
-### Installing fpc on macOS using homebrew
+#### Installing fpc on macOS using Homebrew
 
-On macOS, install [homebrew](https://brew.sh/) and the homebrew fpc 3.0.4 *revision 1* (3.0.4_1) or later package. The *revision 1* there is important — the initial 3.0.4 package will not work as expected on macOS Mojave (10.14) or later.
+On macOS, install [Homebrew](https://brew.sh/) and the homebrew fpc 3.0.4 *revision 1* (3.0.4_1) or later package. The *revision 1* there is important — the initial 3.0.4 package will not work as expected on macOS Mojave (10.14) or later.
 
 ```
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install fpc
 ```
 
-### Installing fpc on macOS from a freepascal.org upstream release
+#### Installing fpc on macOS from a freepascal.org upstream release
 
 If you don’t want to use homebrew but instead prefer to install a freepascal.org upstream release, you must get fpc 3.0.4a or later. The *“a”* there is important — the initial 3.0.4 package will not work as expected on macOS Mojave (10.14) or later.
 
 https://sourceforge.net/projects/freepascal/files/Mac%20OS%20X/3.0.4/fpc-3.0.4a.intel-macosx.dmg/download
 
-### Installing XCode and the XCode command-line tools
+#### Installing XCode and the XCode command-line tools
 
 On macOS, you may also need to have [XCode](https://developer.apple.com/xcode/) and the latest [XCode command-line tools](https://developer.apple.com/download/more/) installed.
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-mkdir -p bin
-cd src
-./build.sh

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# cd to the directory containing this script
+cd "$(dirname "$0")"
+
 MAIN="wattsi"
 SRC=""
 #MODE="DEBUG"
@@ -10,16 +13,12 @@ SRC=""
 #MODE="MEMCHECK"
 MODE="RELEASE"
 
-get_abs_filename() {
-  # We need to get absolute paths because different parts of this script
-  # manipulate files from different directories.
-  echo "$(cd "$(dirname "$1")" || exit; pwd)/$(basename "$1")"
-}
-
-VERSION_FILE="$(get_abs_filename version.inc)"
 PATHS="-Fu${SRC}html -Fi${SRC}html -Fi${SRC}html/entities.inc"
 DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 
+mkdir -p ../bin
+
+VERSION_FILE="version.inc"
 if [[ -f "$VERSION_FILE" ]]; then
   echo "$VERSION_FILE exists: version $(cat $VERSION_FILE)"
 else

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 MAIN="wattsi"
 SRC=""
 #MODE="DEBUG"
@@ -18,10 +20,16 @@ VERSION_FILE="$(get_abs_filename version.inc)"
 PATHS="-Fu${SRC}html -Fi${SRC}html -Fi${SRC}html/entities.inc"
 DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 
-echo "Writing $VERSION_FILE"
-# If you update the fallback below also update WATTSI_LATEST in
-# https://github.com/whatwg/html-build/blob/master/build.sh
-(git rev-list --count HEAD || echo "91") > "$VERSION_FILE"
+if [[ -x "$(command -v git)" ]]; then
+  echo "Writing $VERSION_FILE"
+  # If you update the fallback below also update WATTSI_LATEST in
+  # https://github.com/whatwg/html-build/blob/master/build.sh
+  git rev-list --count HEAD > "$VERSION_FILE"
+elif [[ -f "$VERSION_FILE" ]]; then
+  echo "$VERSION_FILE exists: version $(cat $VERSION_FILE)"
+else
+  echo "$VERSION_FILE must exist, or git must be installed so we can infer it"
+  exit 1
+fi
+
 . ${SRC}lib/compile.sh
-echo "Removing $VERSION_FILE"
-rm "$VERSION_FILE"

--- a/src/build.sh
+++ b/src/build.sh
@@ -20,15 +20,10 @@ VERSION_FILE="$(get_abs_filename version.inc)"
 PATHS="-Fu${SRC}html -Fi${SRC}html -Fi${SRC}html/entities.inc"
 DEFINES="-dUSEROPES -dLINES -dPARSEERROR"
 
-if [[ -x "$(command -v git)" ]]; then
-  echo "Writing $VERSION_FILE"
-  # If you update the fallback below also update WATTSI_LATEST in
-  # https://github.com/whatwg/html-build/blob/master/build.sh
-  git rev-list --count HEAD > "$VERSION_FILE"
-elif [[ -f "$VERSION_FILE" ]]; then
+if [[ -f "$VERSION_FILE" ]]; then
   echo "$VERSION_FILE exists: version $(cat $VERSION_FILE)"
 else
-  echo "$VERSION_FILE must exist, or git must be installed so we can infer it"
+  echo "$VERSION_FILE must exist"
   exit 1
 fi
 

--- a/src/lib/compile.sh
+++ b/src/lib/compile.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # make sure to set MODE ("DEBUG", "PROFILE", or "RELEASE"), MAIN, and SRC before calling this
 # you can add -Fu / -Fi lines to PATHS if you like
 # you can add -dFOO to DEFINES if you like (for any value of FOO)
@@ -27,7 +29,7 @@ IGNORE_MESSAGES=3018,3123,3124,4035,4045,4055,4079,5024,5025,5036,5055,5057,5058
 
 PATHS="-FE${SRC}../bin/ -Fu${SRC}lib -Fi${SRC}lib ${PATHS}"
 BINARY=`basename ${MAIN}`
-if [ "${TESTCMD}" = "" ]; then TESTCMD="bin/${BINARY}"; fi
+if [ "${TESTCMD}" = "" ]; then TESTCMD="bin/${BINARY} --version"; fi
 
 if grep -q ^[0-2][.] <<< $(fpc -iV); then
   echo "ERROR: incorrect fpc version. 3.0.0+ is required."
@@ -51,36 +53,21 @@ then
 
   # DEBUG MODE:
   echo compile: COMPILING - DEBUG MODE
-  fpc ${MAIN}.pas -l- -dDEBUG ${DEFINES} -Ci -Co -CO -Cr -CR -Ct -O- -gt -gl -gh -Sa -veiwnhb ${PATHS} 2>&1 | ${SRC}lib/filter.pl &&
-  cd ${SRC}.. &&
-  #echo compile: Entering directory \`${PWD}/\' &&
-  echo compile: Running ${TESTCMD} &&
-  ${TESTCMD};
-  echo exit value: $?
+  fpc ${MAIN}.pas -l- -dDEBUG ${DEFINES} -Ci -Co -CO -Cr -CR -Ct -O- -gt -gl -gh -Sa -veiwnhb ${PATHS} 2>&1 | ${SRC}lib/filter.pl
 
 elif [ "${MODE}" = "FAST-DEBUG" ]
 then
 
   # FASTER DEBUG MODE:
   echo compile: COMPILING - DEBUG WITH OPTIMISATIONS
-  fpc ${MAIN}.pas -l- -dDEBUG -dOPT ${DEFINES} -Ci -Co -CO -Cr -CR -Ct -O4 -gl -Sa -veiwnhb ${PATHS} 2>&1 | ${SRC}lib/filter.pl &&
-  cd ${SRC}.. &&
-  #echo compile: Entering directory \`${PWD}/\' &&
-  echo compile: Running ${TESTCMD} &&
-  ${TESTCMD};
-  echo exit value: $?
+  fpc ${MAIN}.pas -l- -dDEBUG -dOPT ${DEFINES} -Ci -Co -CO -Cr -CR -Ct -O4 -gl -Sa -veiwnhb ${PATHS} 2>&1 | ${SRC}lib/filter.pl
 
 elif [ "${MODE}" = "FAST" ]
 then
 
   # FASTER MODE:
   echo compile: COMPILING - SIMPLE OPTIMISATIONS ONLY, SYMBOL INFO INCLUDED
-  fpc ${MAIN}.pas -l- -dOPT ${DEFINES} -O4 -Xs- -gl -veiwnhb ${PATHS} 2>&1 | ${SRC}lib/filter.pl &&
-  cd ${SRC}.. &&
-  #echo compile: Entering directory \`${PWD}/\' &&
-  echo compile: Running ${TESTCMD} &&
-  ${TESTCMD};
-  echo exit value: $?
+  fpc ${MAIN}.pas -l- -dOPT ${DEFINES} -O4 -Xs- -gl -veiwnhb ${PATHS} 2>&1 | ${SRC}lib/filter.pl
 
 elif [ "${MODE}" = "VALGRIND-DEBUG" ]
 then
@@ -99,11 +86,7 @@ then
   fpc ${MAIN}.pas -gv -a -l- -dOPT ${DEFINES} -gl -Xs -XX -B -O4 -v0einf -OwALL -Fw${SRC}../bin/opt-feedback ${PATHS} 2>&1 || exit
   rm -f ${SRC}../bin/*.o ${SRC}../bin/*.ppu ${SRC}../bin/*.last &&
   ls -al ${SRC}../bin/${BINARY} &&
-  perl -E 'say ("executable size: " . (-s $ARGV[0]) . " bytes")' ${SRC}../bin/${BINARY} &&
-  cd ${SRC}.. &&
-  #echo compile: Entering directory \`${PWD}/\' &&
-  echo compile: Running ${TESTCMD} &&
-  ${TESTCMD};
+  perl -E 'say ("executable size: " . (-s $ARGV[0]) . " bytes")' ${SRC}../bin/${BINARY}
 
 elif [ "${MODE}" = "PROFILE" ]
 then
@@ -166,11 +149,6 @@ else
   fpc ${MAIN}.pas -a -l- -dRELEASE -dOPT ${DEFINES} -Xs -XX -B -O4 -v0einfm${IGNORE_MESSAGES} -OwALL -Fw${SRC}../bin/opt-feedback ${PATHS} 2>&1 || exit
   rm -f ${SRC}../bin/*.o ${SRC}../bin/*.ppu ${SRC}../bin/*.last &&
   ls -al ${SRC}../bin/${BINARY} &&
-  perl -E 'say ("executable size: " . (-s $ARGV[0]) . " bytes")' ${SRC}../bin/${BINARY} &&
-  cd ${SRC}.. &&
-  #echo compile: Entering directory \`${PWD}/\' &&
-  echo compile: Running ${TESTCMD} &&
-  time ${TESTCMD} &&
-  echo exit value: $?
+  perl -E 'say ("executable size: " . (-s $ARGV[0]) . " bytes")' ${SRC}../bin/${BINARY}
 
 fi


### PR DESCRIPTION
This adds a Dockerfile which, when built, contains the Wattsi executable (with debian:stable-slim as the base). This effectively provides pre-built Wattsi binaries, uploaded to the Docker hub, for those with Docker available. It also gives us CI coverage for Wattsi, which we were lacking.

This closes #192 by removing the hard-coded version. With this in place the HTML build infrastructure should no longer need that.

Along the way, this adds shebangs to various .sh files (required in at least some OSes, including the Debian one we're using in Docker), and removes the test commands from the compile.sh script (those can be run separately, after building).

---

I think this is mergeable now, although it might mess up some of the version number stuff. I'll work on a corresponding html-build PR to use this.