### PR TITLE
Use multi-stage builds in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM debian:stable-slim
-
-COPY src /whatwg/wattsi/src
-WORKDIR /whatwg/wattsi/src
+FROM debian:stable-slim AS builder
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends fp-compiler fp-units-fcl fp-units-net libc6-dev && \
-    ./build.sh && \
-    rm -rf /whatwg/wattsi/src && \
-    mv /whatwg/wattsi/bin/wattsi /whatwg/wattsi/wattsi && \
-    rm -rf /whatwg/wattsi/bin && \
-    apt-get purge -y fp-compiler fp-units-fcl fp-units-net libc6-dev && \
-    apt-get autoremove -y
+    apt-get install -y --no-install-recommends fp-compiler fp-units-fcl fp-units-net libc6-dev
 
-ENTRYPOINT ["/whatwg/wattsi/wattsi"]
+COPY src /whatwg/wattsi/src
+RUN /whatwg/wattsi/src/build.sh
+
+FROM gcr.io/distroless/base
+COPY --from=builder /whatwg/wattsi/bin /whatwg/wattsi/bin
+
+ENTRYPOINT ["/whatwg/wattsi/bin/wattsi"]


### PR DESCRIPTION
This reduces the (uncompressed) size of the resulting Docker image from 99.3 MiB to 25.4 MiB, by starting a fresh image and only copying over the built result. A good chunk of this reduction comes from using the "distroless" base image for the final result (gcr.io/distroless/base).

By splitting the RUN commands, it also reduces iteration time: if the contents of /whatwg/wattsi/src change, running `make docker` will no longer require reinstalling all of the build dependencies inside the container, and instead the cached image with those dependencies will be reused, with only the steps from the COPY command onward re-done. (Splitting the RUN commands in this way was avoided previously because it would increase the size of the image, but with multi-stage builds, this is not a problem. See https://stackoverflow.com/a/61975952/3191.)

---

This is just a minor tweak born out of me trying to learn Docker better. Reviewing/merging it isn't urgent, as the only benefit is making downloads somewhat smaller for people consuming Wattsi in this way.