### PR TITLE
Fix the Makefile for manual builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL=/bin/bash -o pipefail
 .PHONY: clean docker manual
+.DEFAULT_GOAL := manual
 
 clean:
 	rm -rf src/version.inc
@@ -11,4 +12,5 @@ docker:
 	docker build --pull --cache-from whatwg/wattsi --tag whatwg/wattsi .
 
 manual:
+	git rev-list --count HEAD > src/version.inc
 	bash ./src/build.sh


### PR DESCRIPTION
I forgot to update the manual target when I made version.inc mandatory.

Additionally, it's nicer to have the default for "make" be the manual target, instead of clean.