### PR TITLE
Fix handling of MDN annos for heading descendants

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -134,6 +134,19 @@ begin
    Result := True;
 end;
 
+function HasAncestorWithProperties(Element: TNode; const TestProperties: TElementProperties): Boolean;
+begin
+   repeat
+      Element := Element.ParentNode;
+      if (not (Element is TElement)) then
+      begin
+         Result := False;
+         exit;
+      end;
+   until (TElement(Element).HasProperties(TestProperties));
+   Result := True;
+end;
+
 procedure AddMDNBrowserRow(const SupportTable: TElement;
                            const BrowserID: UTF8String;
                            const YesNoUnknown: UTF8String;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1005,24 +1005,30 @@ var
 
       MDNBox := E(eAside);
 
-      if (Element.HasProperties(propHeading)) then
+      if (Element.HasProperties(propHeading) or
+         HasAncestorWithProperties(Element, propHeading)) then
       begin
-         // If this is a heading, we insert the annotation after the element
-         // being annotated. When generating multipage output, inserting the
+         // If the element we want to annotate is either (1) a descendant of
+         // heading, or else (2) is itself a heading, we insert the annotation
+         // after the heading. When generating multipage output, inserting the
          // annotation after the heading ensures that it ends up in the right
          // file. It can otherwise incorrectly end up in the previous split.
          ClassName := 'mdn-anno wrapped';
          MDNBox.SetAttribute('class', ClassName);
-         if (Element.NextElementSibling().GetAttribute('class').AsString = ClassName) then
+         Candidate := Element;
+         while not TElement(Candidate).HasProperties(propHeading) do
+            Candidate := Candidate.ParentNode;
+         TargetAncestor := TElement(Candidate);
+         if (TargetAncestor.NextElementSibling().GetAttribute('class').AsString = ClassName) then
          begin
             // If there's already an MDN box at the point where we want this,
             // then just re-use it (instead of creating another one).
-            MDNBox := TElement(Element.NextElementSibling());
+            MDNBox := TargetAncestor.NextElementSibling();
             IsFirst := False;
          end
          else
          begin
-            TElement(Element.ParentNode).InsertBefore(MDNBox, Element.NextSibling);
+            TElement(TargetAncestor.ParentNode).InsertBefore(MDNBox, TargetAncestor.NextSibling);
             IsFirst := True;
          end
       end


### PR DESCRIPTION
This change causes the handling of MDN annotations for descendants of headings to match the existing handling we’re already using for headings themselves (landed in dab062c). Specifically, if an element is a descendant of a heading, any MDN annotation generated for that element is inserted after the heading element in the DOM (rather than before).

Otherwise, without this change, if an element is a descendant of a heading and we insert an MDN annotation for that element, the annotation is inserted before the heading — which causes the same problem described in the dab062c commit message (in multipage output, the annotation can end up orphaned in the previous split; and in both multipage and single-page output, the annotation isn’t aligned with the heading).

https://html.spec.whatwg.org/multipage/#the-autofocus-attribute is an example of a heading for which, without this change, the annotation does not end up in the right place.