### PR TITLE
Get Wattsi version in the same way as html-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     # This also serves as a *very* minimal test of the executable.
     - name: docker run (get version)
       run: |
-        WATTSI_VERSION=$(docker run "$IMAGE_NAME" --version | sed 's/^wattsi //')
+        WATTSI_VERSION=$(docker run "$IMAGE_NAME" --version | cut -d' ' -f2)
         echo "::set-env name=WATTSI_VERSION::$WATTSI_VERSION"
     - name: docker tag
       run: |


### PR DESCRIPTION
https://github.com/whatwg/html-build/blob/51f79655b59f3872a75ed827439cd4a3de2d98fd/build.sh#L603

It does the same thing right now, but just as well to be consistent.