### PR TITLE
Updates to compile successfully with fpc 3.2.0

### DIFF
--- a/src/html/dom.pas
+++ b/src/html/dom.pas
@@ -117,8 +117,8 @@ type
       function CloneNode(const Deep: Boolean = False): TDocument; override;
       function AppendChild(const NewNode: TNode): TNode; inline;
       function RemoveChild(const OldNode: TNode): TNode; inline;
-      property DocType: TDocumentType read FChildNodes.FDocType;
-      property DocumentElement: TElement read FChildNodes.FDocumentElement;
+      function GetDocType(): TDocumentType; inline;
+      function GetDocumentElement(): TElement; inline;
       property DocumentMode: TDocumentMode read FDocumentMode;
       property FirstChild: TNode read GetFirstChild;
       property LastChild: TNode read GetLastChild;
@@ -750,6 +750,16 @@ begin
    else
       Result := nil;
    Assert(Assigned(Result) = (FChildNodes.Length > 0));
+end;
+
+function TDocument.GetDocType(): TDocumentType;
+begin
+   Result := FChildNodes.FDocType;
+end;
+
+function TDocument.GetDocumentElement(): TElement;
+begin
+   Result := FChildNodes.FDocumentElement;
 end;
 
 function TDocument.GetFirstElementChild(): TElement;

--- a/src/lib/compile.sh
+++ b/src/lib/compile.sh
@@ -6,7 +6,7 @@
 # you can set TESTCMD if you want to run a particular command instead of the obvious
 
 # list of numbered fpc (hint/warning) messages to suppress
-IGNORE_MESSAGES=3018,3123,3124,4035,4045,4055,4079,5024,5025,5036,5055,5057,5058,5059,5071,5092,5093
+IGNORE_MESSAGES=3018,3123,3124,4035,4045,4055,4079,5024,5025,5036,5055,5057,5058,5059,5071,5092,5093,6058
 # 3018 Warning: Constructor should be public
 # 3123 Hint: "open array" not yet supported inside inline procedure/function
 # 3124 Hint: Inlining disabled
@@ -24,6 +24,7 @@ IGNORE_MESSAGES=3018,3123,3124,4035,4045,4055,4079,5024,5025,5036,5055,5057,5058
 # 5071 Note: Private type "arg1.arg2" never used
 # 5092 Hint: Variable "arg1" of a managed type does not seem to be initialized
 # 5093 Warning: function result variable of a managed type does not seem to initialized
+# 6058 Note: Call to subroutine "arg1" marked as inline is not inlined
 
 # XXX -O4 should have LEVEL4 equivalent
 

--- a/src/lib/compile.sh
+++ b/src/lib/compile.sh
@@ -6,7 +6,11 @@
 # you can set TESTCMD if you want to run a particular command instead of the obvious
 
 # list of numbered fpc (hint/warning) messages to suppress
-IGNORE_MESSAGES=3018,3123,3124,4035,4045,4055,4079,5024,5025,5036,5055,5057,5058,5059,5071,5092,5093,6058
+if grep ^3\.2 <<< $(fpc -iV); then
+  IGNORE_MESSAGES=3018,3123,3124,4035,4045,4055,4079,5024,5025,5036,5055,5057,5058,5059,5071,5092,5093,6058
+else
+  IGNORE_MESSAGES=3018,3123,3124,4035,4045,4055,4079,5024,5025,5036,5055,5057,5058,5059,5071,5092,5093
+fi
 # 3018 Warning: Constructor should be public
 # 3123 Hint: "open array" not yet supported inside inline procedure/function
 # 3124 Hint: Inlining disabled

--- a/src/lib/ropes.pas
+++ b/src/lib/ropes.pas
@@ -65,7 +65,7 @@ type
           rfUTF8Inline: (InlineIndex: TUTF8InlineIndexPlusOne; InlineCodepointLength: TZeroableUTF8SequenceLength);
           rfCodepoints: (CodepointsIndex: TCodepointsIndexPlusOne; CodepointsIndexIncluded: Boolean);
       end;
-      function Serialise(const FirstFragment: PRopeFragment): UTF8String;
+      class function Serialise(const FirstFragment: PRopeFragment): UTF8String; static;
    end;
 
    TRopePointer = record
@@ -190,7 +190,7 @@ begin
 end;
 
 
-function RopeInternals.Serialise(const FirstFragment: PRopeFragment): UTF8String;
+class function RopeInternals.Serialise(const FirstFragment: PRopeFragment): UTF8String;
 var
    NeededLength, Offset, Index: Cardinal;
    CurrentFragment: RopeInternals.PRopeFragment;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -2391,7 +2391,7 @@ begin
    Assign(F, FileName);
    Rewrite(F);
    Write(F, '<!DOCTYPE html>');
-   Current := Document.DocumentElement;
+   Current := Document.GetDocumentElement();
    CurrentElement := nil;
    CurrentlyInHighlightedElement := False;
    CurrentHighlightedElementJSON := '';
@@ -2531,8 +2531,8 @@ begin
    Link := ConstructHTMLElement(eScript);
    Link.SetAttribute('src', '/link-fixup.js');
    Link.SetAttribute('defer', '');
-   FirstChild := Document.DocumentElement.FirstChild as TElement;
-   Document.DocumentElement.InsertBefore(Link, FirstChild);
+   FirstChild := Document.GetDocumentElement().FirstChild as TElement;
+   Document.GetDocumentElement().InsertBefore(Link, FirstChild);
    // find body
    Current := Document;
    Inform('Splitting...');
@@ -2664,7 +2664,7 @@ begin
    end;
    // save table of contents section
    SectionDoc := Document.CloneNode(True);
-   SectionDoc.DocumentElement.SetAttribute('class', 'split index');
+   SectionDoc.GetDocumentElement().SetAttribute('class', 'split index');
    Save(SectionDoc, Base + kIndexFilename);
    SectionDoc.Free();
    BigTOC.Remove();
@@ -2674,7 +2674,7 @@ begin
    begin
       SectionName := CurrentSection.GetAttribute(kFileNameAttribute).AsString;
       SectionDoc := Document.CloneNode(True);
-      SectionDoc.DocumentElement.SetAttribute('class', 'split');
+      SectionDoc.GetDocumentElement().SetAttribute('class', 'split');
       // find body
       Current := SectionDoc;
       repeat


### PR DESCRIPTION
fpc 3.2.0 is apparently stricter about a few things, and our existing code has a couple of cases that cause fatal errors when compiling with fpc 3.2.0 — as well as a lot of cases that cause an informational message to get emitted that prevoius fpc versions did not emit for our code.

So in this PR branch, there are multiple commits:

1. A change that replaces the `Document.DocType` and `Document.DocumentElement` properties with `Document.GetDocType()` and `Document.GetDocumentElement()` methods in the `src/html/dom.pas` source, and updates the `src/wattsi.pas` application code to use the `Document.GetDocumentElement()` method. (The `Document.DocType` property was not actually used in the existing code.)

   Otherwise, without that change, fpc fails with these fatal errors:

   > dom.pas(120,55) Error: Record or object type expected
   > dom.pas(121,58) Error: Record or object type expected

   https://wiki.freepascal.org/User_Changes_Trunk#Property_field_access_lists_no_longer_allows_classes explains that the remedy for those errors is to do one of the following:

   * Switch the fields to records or objects
   * Use a method with inline modifier that will result in similar performance
   <br>
   So this change uses the second of those remedies.<br><br>

2. A change that marks the `Serialise()` function in `src/lib/ropes.pas` as an explicit (static) class function.

   Otherwise, without that change, fpc fails with these fatal errors:

   > ropes.pas(759,49) Error: Only class methods, class properties and class variables can be referred with class references
   > ropes.pas(770,49) Error: Only class methods, class properties and class variables can be referred with class references
   > ropes.pas(865,52) Error: Only class methods, class properties and class variables can be referred with class references

3. A change to causes fpc to suppress compiler messages of this form:

   > Note: Call to subroutine "arg1" marked as inline is not inlined

   Otherwise, without that change, fpc emits dozens of those messages.