### PR TITLE
MDN annos: Use <div> rather than <aside>

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1003,7 +1003,7 @@ var
          // No MDN article has a link to this ID.
          exit;
 
-      MDNBox := E(eAside);
+      MDNBox := E(eDiv);
 
       if (Element.HasProperties(propHeading) or
          HasAncestorWithProperties(Element, propHeading)) then


### PR DESCRIPTION
This change makes Wattsi emit `<div>` elements for MDN annos, rather than `<aside>` elements.

Otherwise, without this change, some markup that Wattsi emits for MDN annos doesn’t conform to current HTML spec requirements. Specifically, the HTML spec currently doesn’t allow `<aside>` elements as descendants of `<dt>` elements — but we are intentionally inserting MDN annos as `<dt>` descendants (to get them aligned at point of use). So because of that, for now at least we need to use `<div>` for the annos, rather than `<aside>`.

Relates to https://github.com/whatwg/wattsi/issues/129