### PR TITLE
Only complain about nested dfn/span in heading when it's non-empty

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1288,9 +1288,9 @@ var
                         begin
                            if (InSkippedNode) then
                               Fail('Nested <dfn> or <span> elements in heading ' + LastSeenHeadingID);
-                           InSkippedNode := True;
                            if (CandidateChild.HasChildNodes()) then
                            begin
+                              InSkippedNode := True;
                               CandidateChild := (CandidateChild as TElement).FirstChild;
                               SelectedForTransfer := CandidateChild;
                            end


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/5855.

I did not try this as my local setup is borked again, but I suspect this will work.