### PR TITLE
Drop the “nested dfn or span in heading” error

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1286,8 +1286,6 @@ var
                      begin
                         if ((CandidateChild is TElement) and ((TElement(CandidateChild).IsIdentity(nsHTML, eDFN)) or (TElement(CandidateChild).IsIdentity(nsHTML, eSpan)))) then
                         begin
-                           if (InSkippedNode) then
-                              Fail('Nested <dfn> or <span> elements in heading ' + LastSeenHeadingID);
                            InSkippedNode := True;
                            if (CandidateChild.HasChildNodes()) then
                            begin


### PR DESCRIPTION
This change drops an error that Wattsi otherwise emits for the case where a heading has an empty `span` or `dfn` (that is, with no text content), followed by another `span` or `dfn` in the same heading.

The current code appears to have been (for some reason that’s not obvious now) very intentionally written to report an error for exactly that case — but not for the case where of a heading with *non-empty* `span` or `dfn` followed by another `span` or `dfn` in the same heading.

Without this change, Wattsi reports an error for a reasonable markup case like the one in https://github.com/whatwg/html/pull/5855; that is, this:

```html
<h5 id="rel-alternate"><span id="link-type-alternate"></span>Link type "<dfn data-export=""
data-dfn-for="link/rel,a/rel,area/rel" data-dfn-type="attr-value"><code
data-x="rel-alternate">alternate</code></dfn>"</h5>
```

It’s not at all obvious why we’d want a case like that to be an error.

---

This PR supersedes https://github.com/whatwg/wattsi/pull/132