### PR TITLE
Support dfn types short syntax, "for", (no)export

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1437,6 +1437,12 @@ var
                   Element.SetAttribute(kDataDFNType, DFNType);
                   Element.RemoveAttribute(DFnType);
                end;
+            if (Element.HasAttribute(kDataDFNType)
+               and Element.HasAttribute(kDataExport)) then
+            begin
+               Fail('<dfn> found with dfn type name and redundant'
+                  + ' export attribute; dfn is ' + Describe(Element));
+            end;
             CrossReferenceName := GetTopicIdentifier(Element);
             if (Assigned(InDFN)) then
                Fail('Nested <dfn>: ' + Describe(Element));

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1098,14 +1098,48 @@ var
       kFor = 'for';
       kDataDFNFor = 'data-dfn-for';
       kDataDFNType = 'data-dfn-type';
-      // NOTE: The following array has the subset of dfn types we actually use
-      // in HTML currently. The full set of ~40 supported dfn types is at
-      // https://github.com/tabatkins/bikeshed/blob/master/bikeshed/config/dfnTypes.py#L7
-      // So if we ever start using any types other than the following in HTML,
-      // then at that time we will also need to update this array.
-      kDFNTypes: array[1..9] of UTF8String =
-         ('element', 'element-attr', 'event', 'interface', 'extended-attribute',
-          'method', 'attribute', 'enum-value', 'http-header');
+      // From https://github.com/tabatkins/bikeshed/blob/master/bikeshed/config/dfnTypes.py#L7
+      kDFNTypes: array[1..40] of UTF8String =
+         ('abstract-op',
+          'property',
+          'value',
+          'at-rule',
+          'descriptor',
+          'type',
+          'function',
+          'selector',
+          'element',
+          'element-attr',
+          'attr-value',
+          'element-state',
+          'event',
+          'interface',
+          'namespace',
+          'extended-attribute',
+          'constructor',
+          'method',
+          'argument',
+          'attribute',
+          'callback',
+          'dictionary',
+          'dict-member',
+          'enum',
+          'enum-value',
+          'exception',
+          'const',
+          'typedef',
+          'stringifier',
+          'serializer',
+          'iterator',
+          'maplike',
+          'setlike',
+          'grammar',
+          'scheme',
+          'state',
+          'mode',
+          'context',
+          'facet',
+          'http-header');
    var
       CandidateChild, SelectedForTransfer: TNode;
       CurrentHeadingRank: THeadingRank;

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1091,6 +1091,19 @@ var
    const
       CommitSnapshotBaseURL: AnsiString = '/commit-snapshots/';
       SourceGitBaseURL: AnsiString = 'https://github.com/whatwg/html/commit/';
+      kExport = 'export';
+      kDataExport = 'data-export';
+      kFor = 'for';
+      kDataDFNFor = 'data-dfn-for';
+      kDataDFNType = 'data-dfn-type';
+      // NOTE: The following array has the subset of dfn types we actually use
+      // in HTML currently. The full set of ~40 supported dfn types is at
+      // https://github.com/tabatkins/bikeshed/blob/master/bikeshed/config/dfnTypes.py#L7
+      // So if we ever start using any types other than the following in HTML,
+      // then at that time we will also need to update this array.
+      kDFNTypes: array[1..9] of UTF8String =
+         ('element', 'element-attr', 'event', 'interface', 'extended-attribute',
+          'method', 'attribute', 'enum-value', 'http-header');
    var
       CandidateChild, SelectedForTransfer: TNode;
       CurrentHeadingRank: THeadingRank;
@@ -1104,6 +1117,7 @@ var
       DFNEntry: TDFNEntry;
       ID, HeadingText, ParentHeadingText, SectionNumber, ParentSectionNumber: UTF8String;
       ClassValue: String = '';
+      DFNType: UTF8String = '';
    begin
       Result := True;
       if (Node is TElement) then
@@ -1399,6 +1413,23 @@ var
          begin
             if (Element.HasAttribute(kLTAttribute)) then
                Fail('<dfn> with lt="" found, use data-x="" instead; dfn is ' + Describe(Element));
+            if (Element.HasAttribute(kFor)) then
+            begin
+               ExtractedData := Element.GetAttribute(kFor);
+               Element.SetAttributeDestructively(kDataDFNFor, ExtractedData);
+               Element.RemoveAttribute(kFor);
+            end;
+            if (Element.HasAttribute(kExport)) then
+            begin
+               Element.SetAttribute(kDataExport, '');
+               Element.RemoveAttribute(kExport);
+            end;
+            for DFNType in kDFNTypes do
+               if (Element.HasAttribute(DFnType)) then
+               begin
+                  Element.SetAttribute(kDataDFNType, DFNType);
+                  Element.RemoveAttribute(DFnType);
+               end;
             CrossReferenceName := GetTopicIdentifier(Element);
             if (Assigned(InDFN)) then
                Fail('Nested <dfn>: ' + Describe(Element));

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1093,6 +1093,8 @@ var
       SourceGitBaseURL: AnsiString = 'https://github.com/whatwg/html/commit/';
       kExport = 'export';
       kDataExport = 'data-export';
+      kNoExport = 'noexport';
+      kDataNoExport = 'data-noexport';
       kFor = 'for';
       kDataDFNFor = 'data-dfn-for';
       kDataDFNType = 'data-dfn-type';
@@ -1423,6 +1425,11 @@ var
             begin
                Element.SetAttribute(kDataExport, '');
                Element.RemoveAttribute(kExport);
+            end;
+            if (Element.HasAttribute(kNoExport)) then
+            begin
+               Element.SetAttribute(kDataNoExport, '');
+               Element.RemoveAttribute(kNoExport);
             end;
             for DFNType in kDFNTypes do
                if (Element.HasAttribute(DFnType)) then


### PR DESCRIPTION
This change adds support for doing the following with attributes of `dfn` elements:

* recognize attributes with names that are known dfn types (currently: `element`, `element-attr`, `event`, `interface`, `extended-attribute`, `method`, `attribute`, `enum-value`, and `http-header`), and replace them with corresponding `data-dfn-type=element`, etc., attributes in output

* for any `dfn` element that has an attribute named `for`, replace it in output with an attribute named `data-dfn-for`

* for any `dfn` element with an `export` or `noexport` attribute , replace it with one named `data-export` or `data-noexport`

Relates to https://github.com/whatwg/html/pull/5694/

---

This patch does what I’ve inferred the desired behavior is, based on what I understand from the https://github.com/whatwg/html/pull/5694/. But it’s possible I’m misunderstanding. If so, I’m quite happy to iterate on this further (or completely re-do it…).