### PR TITLE
Revert "Fail with an error if export used w/ dfn type"

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1471,12 +1471,6 @@ var
                   Element.SetAttribute(kDataDFNType, DFNType);
                   Element.RemoveAttribute(DFnType);
                end;
-            if (Element.HasAttribute(kDataDFNType)
-               and Element.HasAttribute(kDataExport)) then
-            begin
-               Fail('<dfn> found with dfn type name and redundant'
-                  + ' export attribute; dfn is ' + Describe(Element));
-            end;
             CrossReferenceName := GetTopicIdentifier(Element);
             if (Assigned(InDFN)) then
                Fail('Nested <dfn>: ' + Describe(Element));


### PR DESCRIPTION
This reverts commit 7e4d1e8f42b6d9f6a4a355c0213aa91b4f47605d
temporarily, as it breaks building the HTML Standard on master. When
https://github.com/whatwg/html/pull/5916 is finished and merged, then we
can add this check back.