### PR TITLE
Fix wattsi compilation on macOS Big Sur.

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -26,4 +26,8 @@ else
   exit 1
 fi
 
+if which xcrun > /dev/null 2>&1; then
+  DEFINES="${DEFINES} -XR$(xcrun --show-sdk-path)"
+fi
+
 . ${SRC}lib/compile.sh


### PR DESCRIPTION
I don't know how often people run into this, but I found this to be necessary to build `wattsi` on one of my macOS Big Sur systems.