### PR TITLE
Ensure all dfn elements have an explicit data-dfn-type attribute

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1196,6 +1196,11 @@ var
          Fail('Element found with dfn type name and redundant'
             + ' export attribute; dfn is ' + Describe(Element));
       end;
+      if ((not Element.HasAttribute(kDataDFNType))
+         and (not Element.HasProperties(propHeading))) then
+      begin
+          Element.SetAttribute(kDataDFNType, 'dfn');
+      end;
    end;
 
    begin


### PR DESCRIPTION
This change causes an explicit `data-dfn-type=dfn` to be added to all `dfn` elements that don’t already have a `data-dfn-type` attribute — ensuring that all `dfn` elements in output have an explicit `data-dfn-type·attribute`.

Otherwise, without this change (without an an explicit `data-dfn-type` on a particular `dfn`), downstream consumers of the spec output might resort to applying heuristics to determine the type — and that could cause the `dfn` to end up with an incorrect type.

For example, Shepherd incorrectly types the "[DOM manipulation task source](https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source)" `dfn` as being an `interface` (most likely because it’s using an heuristic of _“a `dfn` that starts with an uppercase letter is an interface”_).

So, by outputting an an explicit `data-dfn-type=dfn` on all `dfn` elements that don’t already have a `data-dfn-type` attribute, we can ensure that no `dfn` elements end up inadvertently getting mis-typed like that.

There are currently about 2500 `dfn` elements in the source that lack explicit typing, so this affects a significant number.

cc @tidoust, @dontcallmedom
