### PR TITLE
Fail if Append()ing string to Rope in excess of TInlineString size

### DIFF
--- a/src/lib/ropes.pas
+++ b/src/lib/ropes.pas
@@ -48,7 +48,7 @@ type
       TUTF8InlineIndexPlusOne = 0..UTF8InlineSize;
       TCodepointsIndex = 0..CodepointsSize-1;
       TCodepointsIndexPlusOne = 0..CodepointsSize;
-      TInlineString = String[UTF8InlineSize];
+      TInlineString = String[UTF8InlineSize + 1];
       PRopeFragment = ^TRopeFragment;
       TRopeFragment = record
          Next: PRopeFragment;
@@ -963,6 +963,12 @@ begin
    {$IFDEF VERBOSE} if (DebugNow) then Writeln('Ropes: Append(ShortString) on rope @', IntToHex(PtrUInt(@Self), 16), ' with data @', IntToHex(PtrUInt(FValue), 16)); {$ENDIF}
    {$IFDEF VERBOSE} if (DebugNow) then Writeln('Ropes:   Length(FValue)=', Length(FValue)); {$ENDIF}
    Assert(Length(NewString) <= RopeInternals.UTF8InlineSize, 'Maximum size of short string is ' + IntToStr(RopeInternals.UTF8InlineSize));
+   if (Length(NewString) > RopeInternals.UTF8InlineSize) then
+   begin
+      Writeln('Error: Append() call with string length > UTF8InlineSize: "' + NewString + '"');
+      Writeln('Call Append() with a string pointer, not a string: Append(@Foo), not Append(Foo)');
+      Halt(1);
+   end;
    if ((not Assigned(FLast)) or (FLast^.Kind <> rfUTF8Inline) or (RopeInternals.UTF8InlineSize - FLast^.InlineLength < Length(NewString))) then
    begin
       EnsureSize(1, 1);


### PR DESCRIPTION
Something like what’s in the patch in this PR would’ve prevented the problem introduced in https://github.com/whatwg/wattsi/pull/152 and reported in https://github.com/whatwg/wattsi/issues/153.

The problem is: the `Append()` method for Ropes allows passing in either a string or a pointer to a string. And in the case where a string is passed in, the runtime silently truncates the string if it exceeds a certain length (`UTF8InlineSize`, which in practice seems to be 15). But when instead a pointer to a string is passed in, it doesn’t matter how long the string is.

The intent of allowing strings to be passed to `Append()` seems to have been just for very short string _constants_. So we really shouldn’t use  `Append()` with strings other than constants; we should instead always pass in pointers to strings.

So the initial patch in this PR causes Wattsi to fail with an error if the string passed in would end up being truncated, and emits a message suggesting to instead call `Append()` with a string pointer.

The patch is inelegant, and someone with better familiarity with Pascal could probably find a more-clever way. But as far as I know, in the `Rope.Append(const NewString: RopeInternals.TInlineString)` procedure itself, we can’t check if the length of the original string passed to `Append()` exceeds the `TInlineString` type size, `UTF8InlineSize`.

We can’t check there because the runtime truncates the original string to the `TInlineString` type size when `Append()` is called. So if the length of the original string exceeds the size of the `TInlineString` type — `UTF8InlineSize` — then the length of `NewString` will be the length of the truncated string (truncated down to `UTF8InlineSize`).

So this existing assert:

https://github.com/whatwg/wattsi/blob/4cabebbf06da7745aa5436371cb37a916f3fdc35/src/lib/ropes.pas#L965

…will never work unless we allow the size of `TInlineString` to be greater than `UTF8InlineSize` (as the initial patch in this PR does) — because otherwise, `NewString` will _always_ be less than or equal to `UTF8InlineSize`; that’s because, if `NewString`  comes from a string whose length is greater than `UTF8InlineSize` (the size of the `TInlineString` type), the runtime will always truncate it down to `UTF8InlineSize`.

So the initial patch in this PR allows the size of the `TInlineString` type to be `UTF8InlineSize + 1`, but then fails/exits with an error message if `Append()` is called with a string bigger than `UTF8InlineSize`.

Because `Append()` is the only place where `TInlineString` is ever used in the existing code, this seems safe.
