### PR TITLE
Fix the <ref> processing again

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1585,19 +1585,25 @@ var
             ListNode^.Next := References[ReferenceName];
             References[ReferenceName] := ListNode;
             MissingReferences[ReferenceName] := ListNode;
+
             NewLink := ConstructHTMLElement(eA);
             Scratch := Default(Rope);
+            ExtractedData := Element.TextContent.ExtractAll();
             Scratch.Append('#refs');
-            Scratch.Append(@ReferenceName);
+            Scratch.AppendDestructively(ExtractedData);
             NewLink.SetAttributeDestructively('href', Scratch);
+
             Scratch := Default(Rope);
+            ExtractedData := Element.TextContent.ExtractAll();
             Scratch.Append('[');
-            Scratch.Append(@ReferenceName);
+            Scratch.AppendDestructively(ExtractedData);
             Scratch.Append(']');
             NewLink.AppendChild(TText.CreateDestructively(Scratch));
+
             (Node.ParentNode as TElement).ReplaceChild(NewLink, Node);
             Node.Free();
             Node := NewLink;
+
             Result := ProcessNode(Node);
          end
          else


### PR DESCRIPTION
The string/rope semantics continue to bite us. The original fix in bd1cd4460609a8284bb92fd4a4c407f4cc7b68fb was not correct, for unclear reasons. This version uses ExtractAll() to ensure we get a fresh CutRope that we can AppendDestructively() to Scratch, which is more in line with what other parts of the file do.