### PR TITLE
Allow Append()ing normal ShortStrings (length ≦ 255) to Ropes, switch DOM implementation to using that, and use that for generating reference links

### DIFF
--- a/src/html/dom.pas
+++ b/src/html/dom.pas
@@ -1704,7 +1704,7 @@ begin
    if (Value <> '') then
    begin
       {$IFOPT C+} AssertStringIsConstant(Value); {$ENDIF}
-      R.Append(@Value);
+      R.Append(Value);
    end;
    FAttributes[Name] := R;
 end;
@@ -1761,7 +1761,7 @@ begin
    if (NewData <> '') then
    begin
       {$IFOPT C+} AssertStringIsConstant(NewData); {$ENDIF}
-      FData.Append(@NewData);
+      FData.Append(NewData);
    end;
 end;
 

--- a/src/lib/ropes.pas
+++ b/src/lib/ropes.pas
@@ -41,14 +41,14 @@ type
     private
      const
       FragmentPayloadSize = SizeOf(TFixedSizeRopeFragment);
-      UTF8InlineSize = FragmentPayloadSize - SizeOf(Byte);
+      UTF8InlineSize = 255;
       CodepointsSize = (FragmentPayloadSize-SizeOf(Byte)) div SizeOf(TUnicodeCodepoint);
      type
       TUTF8InlineIndex = 0..UTF8InlineSize-1;
       TUTF8InlineIndexPlusOne = 0..UTF8InlineSize;
       TCodepointsIndex = 0..CodepointsSize-1;
       TCodepointsIndexPlusOne = 0..CodepointsSize;
-      TInlineString = String[UTF8InlineSize + 1];
+      TInlineString = String[UTF8InlineSize];
       PRopeFragment = ^TRopeFragment;
       TRopeFragment = record
          Next: PRopeFragment;
@@ -963,12 +963,6 @@ begin
    {$IFDEF VERBOSE} if (DebugNow) then Writeln('Ropes: Append(ShortString) on rope @', IntToHex(PtrUInt(@Self), 16), ' with data @', IntToHex(PtrUInt(FValue), 16)); {$ENDIF}
    {$IFDEF VERBOSE} if (DebugNow) then Writeln('Ropes:   Length(FValue)=', Length(FValue)); {$ENDIF}
    Assert(Length(NewString) <= RopeInternals.UTF8InlineSize, 'Maximum size of short string is ' + IntToStr(RopeInternals.UTF8InlineSize));
-   if (Length(NewString) > RopeInternals.UTF8InlineSize) then
-   begin
-      Writeln('Error: Append() call with string length > UTF8InlineSize: "' + NewString + '"');
-      Writeln('Call Append() with a string pointer, not a string: Append(@Foo), not Append(Foo)');
-      Halt(1);
-   end;
    if ((not Assigned(FLast)) or (FLast^.Kind <> rfUTF8Inline) or (RopeInternals.UTF8InlineSize - FLast^.InlineLength < Length(NewString))) then
    begin
       EnsureSize(1, 1);

--- a/src/lib/ropes.pas
+++ b/src/lib/ropes.pas
@@ -41,14 +41,14 @@ type
     private
      const
       FragmentPayloadSize = SizeOf(TFixedSizeRopeFragment);
-      UTF8InlineSize = 255;
+      UTF8InlineSize = 30;
       CodepointsSize = (FragmentPayloadSize-SizeOf(Byte)) div SizeOf(TUnicodeCodepoint);
      type
       TUTF8InlineIndex = 0..UTF8InlineSize-1;
       TUTF8InlineIndexPlusOne = 0..UTF8InlineSize;
       TCodepointsIndex = 0..CodepointsSize-1;
       TCodepointsIndexPlusOne = 0..CodepointsSize;
-      TInlineString = String[UTF8InlineSize];
+      TInlineString = String[UTF8InlineSize + 1];
       PRopeFragment = ^TRopeFragment;
       TRopeFragment = record
          Next: PRopeFragment;
@@ -963,6 +963,11 @@ begin
    {$IFDEF VERBOSE} if (DebugNow) then Writeln('Ropes: Append(ShortString) on rope @', IntToHex(PtrUInt(@Self), 16), ' with data @', IntToHex(PtrUInt(FValue), 16)); {$ENDIF}
    {$IFDEF VERBOSE} if (DebugNow) then Writeln('Ropes:   Length(FValue)=', Length(FValue)); {$ENDIF}
    Assert(Length(NewString) <= RopeInternals.UTF8InlineSize, 'Maximum size of short string is ' + IntToStr(RopeInternals.UTF8InlineSize));
+   if (Length(NewString) > RopeInternals.UTF8InlineSize) then
+   begin
+      Writeln('Error: Operation attempted with string length > UTF8InlineSize: "' + NewString + '..."');
+      Halt(1);
+   end;
    if ((not Assigned(FLast)) or (FLast^.Kind <> rfUTF8Inline) or (RopeInternals.UTF8InlineSize - FLast^.InlineLength < Length(NewString))) then
    begin
       EnsureSize(1, 1);

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1489,8 +1489,10 @@ var
          // For vReview the title is already taken care of
          if (Element.IsIdentity(nsHTML, eTitle)) and (Variant = vSnap) then
          begin
+            Scratch := Default(Rope);
+            Scratch.Append(@SourceGitSHA);
             Element.AppendChild(TText.Create(' (Commit Snapshot '));
-            Element.AppendChild(TText.Create(SourceGitSHA));
+            Element.AppendChild(TText.CreateDestructively(Scratch));
             Element.AppendChild(TText.Create(')'));
          end
          else
@@ -1550,7 +1552,9 @@ var
          else
          if (Element.isIdentity(nsHTML, eA) and (Element.GetAttribute('class').AsString = 'sha-link') and (Variant = vSnap)) then
          begin
-            Element.AppendChild(TText.Create(SourceGitSHA));
+            Scratch := Default(Rope);
+            Scratch.Append(@SourceGitSHA);
+            Element.AppendChild(TText.CreateDestructively(Scratch));
             Element.AppendChild(TText.Create(' commit'));
             Scratch := Default(Rope);
             Scratch.Append(@SourceGitBaseURL);

--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1587,18 +1587,8 @@ var
             MissingReferences[ReferenceName] := ListNode;
 
             NewLink := ConstructHTMLElement(eA);
-            Scratch := Default(Rope);
-            ExtractedData := Element.TextContent.ExtractAll();
-            Scratch.Append('#refs');
-            Scratch.AppendDestructively(ExtractedData);
-            NewLink.SetAttributeDestructively('href', Scratch);
-
-            Scratch := Default(Rope);
-            ExtractedData := Element.TextContent.ExtractAll();
-            Scratch.Append('[');
-            Scratch.AppendDestructively(ExtractedData);
-            Scratch.Append(']');
-            NewLink.AppendChild(TText.CreateDestructively(Scratch));
+            NewLink.SetAttribute('href', '#refs' + ReferenceName);
+            NewLink.AppendChild(TText.Create('[' + ReferenceName + ']'));
 
             (Node.ParentNode as TElement).ReplaceChild(NewLink, Node);
             Node.Free();


### PR DESCRIPTION
Relates to #153. This change reverts 0ad4342 and increases to 255 the length of strings that can be passed directly to Rope≫Append() without getting truncated. Otherwise, without this change, any string passed directly to Rope≫Append() whose length exceeds a particular system-dependent limit (which in practice seems to be 15) will get silently truncated.

This change allows us to append strings to Ropes in the way we’d intuitively expect to — rather than instead needing to forever remember that we otherwise have to:
1. Create an additional CutRope (e.g., with ExtractedData)
2. Append our strings to that CutRope.
3. Use Rope≫AppendDestructively() to append that CutRope to whatever Rope we’re working with.

Further, the change switches the DOM implementation to append strings directly when setting attribute values and when appending text nodes and comments. That in turn allows passing non-constant strings to Element≫AppendChild() and Document≫AppendChild() and Element≫SetAttribute().

Otherwise, without that change, the strings we use for attribute values and text nodes and comments either must be constants, or else we have to create CutRopes, append strings to them, and then use TText.CreateDestructively() (to create text nodes and comments) and Element≫SetAttributeDestructively() (to set attribute values).

The change also includes a commit that switches the code for generating reference links to using a normal Append() and simple string concatenation — rather than needing to append a `Scratch` Rope built using an `ExtractedData` CutRope.