### PR TITLE
CI: Create a multiplatform docker image using docker buildx features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,20 @@ jobs:
       packages: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Create version file
       run: |
         git rev-list --count HEAD > src/version.inc
     - name: Build
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         load: true
@@ -37,17 +43,18 @@ jobs:
         echo "WATTSI_VERSION=$WATTSI_VERSION" >> $GITHUB_ENV
     - name: Login
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: |
           ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.WATTSI_VERSION }}
           ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
Per the Docker documentation [1], setup a github actions workflow to create both an amd64 and an arm64 image.

This can be tested locally like so:

- Create a docker-container builder that will use qemu-static-user

`docker buildx create --name container --driver=docker-container --use`

- Run the build using docker buildx with that new 'builder'

```
docker buildx build --builder=container \
    --platform linux/amd64,linux/arm64 .
```

Also update the actions to their latest revs.

[1] https://docs.docker.com/build/ci/github-actions/multi-platform/