### PR TITLE
Fix tracking-vector image in dark-mode

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1692,6 +1692,7 @@ var
                                               'alt', '(This is a tracking vector.)',
                                               'width', '46',
                                               'height', '64',
+                                              'class', 'darkmode-aware',
                                               'crossorigin', ''])]);
             (Node.ParentNode as TElement).ReplaceChild(TempElement, Node);
             Node.Free();


### PR DESCRIPTION
Since https://github.com/whatwg/whatwg.org/pull/444 *tracking-vector.svg* is now darkmode-aware, i.e. its fill color will be dependent on the user's darkmode settings. However from https://github.com/whatwg/whatwg.org/pull/439 `<img>` tags pointing at svg images that don't have a `"darkmode-aware"` class are given a white background by default. This makes the tracking-vector image fully white when seen in dark-mode. This PR aims at fixing it by adding the class on the generated `<img>` element.

Note that I'm not entirely sure this is the only source for this image in all the specs, but I tested it with html-build where it already handles a bunch.

Before:
<img width="556" alt="Screenshot 2024-08-06 at 9 24 33 AM" src="https://github.com/user-attachments/assets/b705c216-884e-4a1c-9418-b744a8872bae">


After:
<img width="558" alt="Screenshot 2024-08-06 at 9 25 43 AM" src="https://github.com/user-attachments/assets/f8f1c1dc-444d-4f44-801a-ea2dfba02282">


