### PR TITLE
Use HTML_PUBDATE env var if set, to set 'pubdate'

### DIFF
--- a/src/wattsi.pas
+++ b/src/wattsi.pas
@@ -1150,6 +1150,7 @@ var
       ExtractedData: CutRope;
       ClassName, Instruction, CrossReferenceName, ReferenceName, DataDFNType: UTF8String;
       TodayYear, TodayMonth, TodayDay: Word;
+      EnvDate: string;  UseTimestamp: Int64;  DT: TDateTime;
       InSkippedNode, UsedLI: Boolean;
       ListNode: PElementListNode;
       DFNEntry: TDFNEntry;
@@ -1462,7 +1463,23 @@ var
                else
                begin
                   Scratch := Default(Rope);
-                  DecodeDate(Date, TodayYear, TodayMonth, TodayDay);
+                  EnvDate := GetEnvironmentVariable('HTML_PUBDATE');
+                  if EnvDate <> '' then
+                  begin
+                     if TryStrToInt64(EnvDate, UseTimestamp) then
+                     begin
+                        // Convert seconds-since-1970 to TDateTime
+                        DT := UnixToDateTime(UseTimestamp, False); // False = timestamp is UTC
+                     end
+                     else
+                     begin
+                        // fallback: keep original Date variable if parse fails
+                        DT := Date;
+                     end;
+                  end
+                  else
+                     DT := Date; // original variable
+                  DecodeDate(DT, TodayYear, TodayMonth, TodayDay);
                   if (ClassName = 'pubdate') then
                   begin
                      Scratch.Append(IntToStr(TodayDay));


### PR DESCRIPTION
HTML_PUBDATE is expected to be a unix timestamp

BTW this permits to ensures reproducible build (eg. on Debian) when the env. var is set